### PR TITLE
Update standard launch url for LTI 1.1

### DIFF
--- a/ansible/roles/illumidesk/templates/lti11-cartridge.xml.j2
+++ b/ansible/roles/illumidesk/templates/lti11-cartridge.xml.j2
@@ -6,7 +6,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemalocation="http://www.imsglobal.org/xsd/imslticc_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticc_v1p0.xsd http://www.imsglobal.org/xsd/imsbasiclti_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imsbasiclti_v1p0p1.xsd http://www.imsglobal.org/xsd/imslticm_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticm_v1p0.xsd http://www.imsglobal.org/xsd/imslticp_v1p0 http://www.imsglobal.org/xsd/lti/ltiv1p0/imslticp_v1p0.xsd">
     <blti:title>IllumiDesk</blti:title>
     <blti:description></blti:description>
-    <blti:launch_url>https://{{org_name}}.{{tld}}/lti/11/{{org_name}}.xml</blti:launch_url>
+    <blti:launch_url>https://{{org_name}}.{{tld}}/hub/lti/launch</blti:launch_url>
     <blti:extensions platform="canvas.instructure.com">
         <lticm:property name="privacy_level">public</lticm:property>
         <lticm:property name="domain">{{org_name}}.illumidesk.com</lticm:property>


### PR DESCRIPTION
Updates the standard launch URL to use `.../hub/lti/launch` for all tool consumers.

Errors were occurring with some tool consumers when initiating launch requests with POST methods, particularly when the XML cartridge link is hosted by a CDN such as CloudFront.