### PR TITLE
Run JupyterHub with Python 3.8

### DIFF
--- a/ansible/roles/jupyterhub/tasks/main.yml
+++ b/ansible/roles/jupyterhub/tasks/main.yml
@@ -46,15 +46,15 @@
   set_fact:
     lti11_shared_secret_result={{ _lti11_shared_secret_result.stdout }}
 
-- name: copy the jupyterhub configuration file
-  copy:
-    src: jupyterhub_config.py
-    dest: "{{ working_dir }}/jupyterhub_config.py"
-
 - name: copy requirements.txt for base jupyterhub image
   copy:
     src: requirements.txt
     dest: "{{ working_dir }}/jupyterhub-requirements.txt"
+
+- name: copy the jupyterhub configuration file
+  copy:
+    src: jupyterhub_config.py
+    dest: "{{ working_dir }}/jupyterhub_config.py"
 
 - name: copy postgres utility scripts
   copy:

--- a/ansible/roles/jupyterhub/templates/Dockerfile.jhub.j2
+++ b/ansible/roles/jupyterhub/templates/Dockerfile.jhub.j2
@@ -1,22 +1,29 @@
-ARG BASE_IMAGE={{docker_jhub_base_image}}
+ARG BASE_IMAGE=ubuntu:bionic-20200311
 FROM $BASE_IMAGE
-
-ENV PYTHONPATH=/usr/local/lib/python3.6/dist-packages:$PYTHONPATH
-
-# always make sure pip is up to date!
-RUN python3 -m pip install --no-cache --upgrade setuptools pip
 
 RUN apt-get update \
  && apt-get install -yq --no-install-recommends \
     apt-utils \
     fonts-liberation \
+    git \
     libpq-dev \
     nano \
     postgresql-client \
+    software-properties-common \
     sudo \
     wget \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
+
+RUN add-apt-repository ppa:deadsnakes/ppa \
+ && apt-get install -y \
+    python3.8 \
+    python3-pip
+
+ENV PYTHONPATH=/usr/local/lib/python3.8/dist-packages:$PYTHONPATH
+
+# always make sure pip is up to date!
+RUN python3 -m pip install --no-cache --upgrade setuptools pip
 
 # Enable prompt color in the skeleton .bashrc before creating the default JH_USER
 RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc
@@ -39,10 +46,10 @@ COPY share/templates/. /usr/local/share/jupyterhub/templates/.
 # /etc/jupyterhub/jupyterhub_config.py by default
 COPY jupyterhub_config.py /etc/jupyterhub/jupyterhub_config.py
 
+WORKDIR /srv/jupyterhub
+
 # Get cull-idle from jupyterhub examples folder
 RUN wget https://raw.githubusercontent.com/jupyterhub/jupyterhub/d126baa443ad7d893be2ff4a70afe9ef5b8a4a1a/examples/cull-idle/cull_idle_servers.py
-
-WORKDIR /srv/jupyterhub
 
 # Copy postgres util script and update permissions
 COPY wait-for-postgres.sh /srv/jupyterhub/wait-for-postgres.sh
@@ -50,6 +57,6 @@ RUN chmod +x /srv/jupyterhub/wait-for-postgres.sh
 
 # Run standard command but wait for postgres
 # https://docs.docker.com/compose/startup-order/
-CMD ["/srv/jupyterhub/wait-for-postgres.sh", "python3", "jupyterhub", "-f", "/etc/jupyterhub/jupyterhub_config.py"]
+CMD ["/srv/jupyterhub/wait-for-postgres.sh", "python3.8", "jupyterhub", "-f", "/etc/jupyterhub/jupyterhub_config.py"]
 
 HEALTHCHECK CMD curl --fail http://localhost:8081/ || exit 1


### PR DESCRIPTION
This update installs `python 3.8` in JupyterHub's base image. Using python 3.8 will allow us to:

- Move away from Tornado's coroutines and replace them with native async / awaits.
- Using python 3.8 also allows us to use other frameworks within the same package namespace that may require this python version or above.