### PR TITLE
Update make deploy command for one step setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ venv:
 	${PYTHON} -m pip install -r requirements.txt
 	${PYTHON} -m pip install -r dev-requirements.txt
 
-deploy:
-	ansible-playbook -i ansible/hosts \
+deploy: prepare
+	${VENV_BIN}/ansible-playbook -i ansible/hosts \
       ansible/provisioning.yml
 
 lint: venv


### PR DESCRIPTION
Update `make deploy` command to check for virtual environment, install the virtual environment if it does not exist, and run the setup script with the virtual environment's python bin.