### PR TITLE
Add curl to jupyterhub

### DIFF
--- a/ansible/roles/jupyterhub/templates/Dockerfile.jhub.j2
+++ b/ansible/roles/jupyterhub/templates/Dockerfile.jhub.j2
@@ -4,6 +4,7 @@ FROM $BASE_IMAGE
 RUN apt-get update \
  && apt-get install -yq --no-install-recommends \
     apt-utils \
+    curl \
     fonts-liberation \
     git \
     libpq-dev \


### PR DESCRIPTION
Add curl to JupyterHub image to correctly display health status with docker container.