### PR TITLE
Update imports and modify authenticator entry point setup

### DIFF
--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
@@ -1,14 +1,9 @@
-import sys
-import asyncio
-import json
-import logging
 import os
-import pwd
-import re
-import shutil
 import requests
 
+from illumidesk.authenticators.authenticator import LTI11Authenticator
 from illumidesk.spawners.spawner import IllumiDeskDockerSpawner
+
 
 c = get_config()
 
@@ -26,9 +21,7 @@ c.JupyterHub.allow_named_servers = False
 c.JupyterHub.data_files_path = '/usr/local/share/jupyterhub/'
 
 # Use custom logo
-c.JupyterHub.logo_file = os.path.join(
-    '/usr/local/share/jupyterhub/', 'static', 'images', 'illumidesk-80.png'
-)
+c.JupyterHub.logo_file = os.path.join('/usr/local/share/jupyterhub/', 'static', 'images', 'illumidesk-80.png')
 
 # Template files
 c.JupyterHub.template_paths = ('/usr/local/share/jupyterhub/templates',)
@@ -40,9 +33,7 @@ c.JupyterHub.hub_ip = '0.0.0.0'
 c.JupyterHub.hub_connect_ip = 'jupyterhub'
 
 # Provide iframe support
-c.JupyterHub.tornado_settings = {
-    "headers": {"Content-Security-Policy": "frame-ancestors 'self' *"}
-}
+c.JupyterHub.tornado_settings = {"headers": {"Content-Security-Policy": "frame-ancestors 'self' *"}}
 
 # Load data files
 c.JupyterHub.data_files_path = '/usr/local/share/jupyterhub/'
@@ -60,13 +51,8 @@ c.JupyterHub.load_groups = {
         'instructor1',
         'instructor2',
         os.environ.get('DEMO_GRADER_NAME'),
-    ],
-    os.environ.get('DEMO_STUDENT_GROUP'): [
-        'student1',
-        'bitdiddle',
-        'hacker',
-        'reasoner',
-    ],
+    ],  # noqa: E231
+    os.environ.get('DEMO_STUDENT_GROUP'): ['student1', 'bitdiddle', 'hacker', 'reasoner',],  # noqa: E231
 }
 
 # Allow admin access to end-user notebooks
@@ -93,8 +79,8 @@ c.JupyterHub.services = [
     },
     {
         'name': 'announcement',
-        'url': f'http://0.0.0.0:{int(announcement_port)}', # allow external connections with 0.0.0.0
-        'command': f'python3 /srv/jupyterhub/announcement.py --port {int(announcement_port)} --api-prefix /services/announcement'.split()
+        'url': f'http://0.0.0.0:{int(announcement_port)}',  # allow external connections with 0.0.0.0
+        'command': f'python3 /srv/jupyterhub/announcement.py --port {int(announcement_port)} --api-prefix /services/announcement'.split(),
     },
 ]
 
@@ -110,7 +96,7 @@ c.JupyterHub.db_url = 'postgresql://{user}:{password}@{host}/{db}'.format(
 )
 
 # LTI 1.1 authenticator class.
-c.JupyterHub.authenticator_class = 'illumidesk.authenticators.authenticator.LTI11Authenticator'
+c.JupyterHub.authenticator_class = LTI11Authenticator
 
 # Spawn containers with custom dockerspawner class
 c.JupyterHub.spawner_class = IllumiDeskDockerSpawner
@@ -132,7 +118,7 @@ c.JupyterHub.proxy_class = TraefikTomlProxy
 # mark the proxy as externally managed
 c.TraefikTomlProxy.should_start = False
 
-# indicate the proxy url to allow register new routes 
+# indicate the proxy url to allow register new routes
 c.TraefikProxy.traefik_api_url = os.environ.get('PROXY_API_URL') or 'http://reverse-proxy:8099'
 
 # traefik api endpoint login password
@@ -155,9 +141,7 @@ c.TraefikTomlProxy.toml_dynamic_config_file = "/etc/traefik/rules.toml"
 ##########################################
 
 c.LTIAuthenticator.consumers = {
-    os.environ.get('LTI_CONSUMER_KEY')
-    or 'consumer_key': os.environ.get('LTI_SHARED_SECRET')
-    or 'shared_secret'
+    os.environ.get('LTI_CONSUMER_KEY') or 'consumer_key': os.environ.get('LTI_SHARED_SECRET') or 'shared_secret'
 }
 
 ##########################################

--- a/src/illumidesk/authenticators/authenticator.py
+++ b/src/illumidesk/authenticators/authenticator.py
@@ -1,13 +1,16 @@
 import os
 import json
+
 from jupyterhub.handlers import BaseHandler
 
 from ltiauthenticator import LTIAuthenticator
+
 from tornado.web import HTTPError
 from tornado.httpclient import AsyncHTTPClient
+
 from illumidesk.apis.jupyterhub_api import JupyterHubAPI
-from .utils import LTIUtils
-from .validator import LTI11LaunchValidator
+from illumidesk.authenticators.utils import LTIUtils
+from illumidesk.authenticators.validator import LTI11LaunchValidator
 
 
 class LTI11Authenticator(LTIAuthenticator):

--- a/src/setup.py
+++ b/src/setup.py
@@ -44,9 +44,4 @@ setup(
         'filelock==3.0.12',
     ],  # noqa: E231
     package_data={'': ['*.html'],},  # noqa: E231
-    entry_points={
-        'jupyterhub.authenticators': [
-            'illumidesklti11 = illumidesk.authenticators.authenticator.LTI11Authenticator',
-        ],  # noqa: E231
-    },
 )


### PR DESCRIPTION
- Remove unused imports from jupyterhub_config
- Remove setup entry point for the authenticator
- Import custom authenticator for LTI 11 with full path