### PR TITLE
Remove ansible-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,6 @@ repos:
       - id: black
         language_version: python3.8
 
-  - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.2.0
-    hooks:
-      - id: ansible-lint
-        files: \.(yaml|yml)$
-
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -5,7 +5,6 @@ set -e
 run_linters () {
   echo "Running linters ..."
   flake8 src/
-  ansible-lint
   black --check src/
 }
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ deploy: prepare
 
 lint: venv
 	${VENV_BIN}/flake8 src
-	${VENV_BIN}/ansible-lint
 	${VENV_BIN}/black .
 
 test: venv

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 # used in tests
-ansible-lint==4.2.0
 black==19.10b0
 codecov==2.0.22
 coverage==5.1


### PR DESCRIPTION
There are too many security issues being raised with ansible-lint and its underlying dependencies - removing ansible-lint from the project.