### PR TITLE
Fixes grades submission for moodle

### DIFF
--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
@@ -220,9 +220,11 @@ c.DockerSpawner.volumes = {
 # END CUSTOM DOCKERSPAWNER
 ##########################################
 
-# Custom Handlers used to send grades to LMS
+# Custom Handlers 
+# the first one is used to send grades to LMS
+# this url pattern was changed to accept spaces in the assignment name
 c.JupyterHub.extra_handlers= [
-    (r'/submit-grades/(?P<course_id>\w+)/(?P<assignment_name>\w+)', 'illumidesk.handlers.lms_grades.SendGradesHandler'),
+    (r'/submit-grades/(?P<course_id>\w+)/(?P<assignment_name>.*)$', 'illumidesk.handlers.lms_grades.SendGradesHandler'),
 ]
 
 ##########################################

--- a/ansible/roles/jupyterhub/templates/env.jhub.j2
+++ b/ansible/roles/jupyterhub/templates/env.jhub.j2
@@ -46,7 +46,7 @@ PGDATA=/var/lib/postgresql/data
 
 MNT_HOME_DIR_UID=1000
 MNT_HOME_DIR_GID=100
-MNT_ROOT=/mnt/
+MNT_ROOT={{mnt_root}}
 
 # lti 1.1
 LTI_CONSUMER_KEY={{lti11_consumer_key}}

--- a/src/setup.py
+++ b/src/setup.py
@@ -43,6 +43,7 @@ setup(
         'quart==0.11.5',
         'filelock==3.0.12',
         'pylti==0.7.0',
+        'lti==0.9.5',
     ],  # noqa: E231
     package_data={'': ['*.html'],},  # noqa: E231
 )

--- a/src/setup.py
+++ b/src/setup.py
@@ -42,7 +42,6 @@ setup(
         'nbgrader>=0.6.1',
         'quart==0.11.5',
         'filelock==3.0.12',
-        'pylti==0.7.0',
         'lti==0.9.5',
     ],  # noqa: E231
     package_data={'': ['*.html'],},  # noqa: E231

--- a/tests/illumidesk/handlers/test_lms_grades.py
+++ b/tests/illumidesk/handlers/test_lms_grades.py
@@ -114,7 +114,7 @@ def test_grades_sender_raises_an_error_if_there_are_not_grades(tmp_path):
     sender_controlfile = LTIGradeSender('course1', 'problem1')
     # create a mock for our method that searches grades from gradebook.db
     with patch.object(
-        LTIGradeSender, '_retrieve_grades_from_db', return_value=[]
+        LTIGradeSender, '_retrieve_grades_from_db', return_value=(lambda: 10, [])
     ):
         with pytest.raises(AssignmentWithoutGradesError):
             sender_controlfile.send_grades()
@@ -134,7 +134,7 @@ def test_grades_sender_raises_an_error_if_assignment_not_found_in_control_file(t
     ]
     # create a mock for our method that searches grades from gradebook.db
     with patch.object(
-        LTIGradeSender, '_retrieve_grades_from_db', return_value=grades_nbgrader
+        LTIGradeSender, '_retrieve_grades_from_db', return_value=(lambda:10, grades_nbgrader)
     ):
         with pytest.raises(GradesSenderMissingInfoError):
             sender_controlfile.send_grades()

--- a/tests/illumidesk/handlers/test_lms_grades.py
+++ b/tests/illumidesk/handlers/test_lms_grades.py
@@ -134,7 +134,7 @@ def test_grades_sender_raises_an_error_if_assignment_not_found_in_control_file(t
     ]
     # create a mock for our method that searches grades from gradebook.db
     with patch.object(
-        LTIGradeSender, '_retrieve_grades_from_db', return_value=(lambda:10, grades_nbgrader)
+        LTIGradeSender, '_retrieve_grades_from_db', return_value=(lambda: 10, grades_nbgrader)
     ):
         with pytest.raises(GradesSenderMissingInfoError):
             sender_controlfile.send_grades()


### PR DESCRIPTION
Replace **pylti** package with **lti** to generate the outcome request. This package contains a class called `OutcomeRequest` that is responsible for create the xml and make the request with all the headers required by Oauth1.0 mechanism but adding the extra `oauth_body_hash` value that moodle is expecting. 
Also Moodle vendor is sending a **json** in `lis_result_sourcedid` field thus the GradesSender  is checking its value to use it correctly.
Finally, the grade score is calculating with Assignment.max_score  value to send number between 1-0. _Maybe we can ilater override some methods in this class to use `resultTotalScore` instead of `resultScore`._