### PR TITLE
Create Traefik's rules.toml with copy

### DIFF
--- a/ansible/roles/reverse-proxy/tasks/main.yml
+++ b/ansible/roles/reverse-proxy/tasks/main.yml
@@ -4,14 +4,13 @@
     path: "{{ working_dir }}/reverse-proxy"
     state: directory
 
-- name: create rules.toml file (if not exists)
-  file:
-    path: "{{ working_dir }}/reverse-proxy/rules.toml"
-    state: touch
-  register: rules
-  changed_when: rules.diff.before.state == "absent"
-
 - name: copy the traefik configuration file
   copy:
     src: traefik.toml
     dest: "{{ working_dir }}/reverse-proxy/traefik.toml"
+
+- name: copy the rules.toml file
+  copy:
+    src: rules.toml
+    dest: "{{ working_dir }}/reverse-proxy/rules.toml"
+    mode: '0755'


### PR DESCRIPTION
Using touch to create the blank `rules.toml` file complicated the permissions setup so moved to use a blank copy instead.