### PR TITLE
Rsync ignore 

### DIFF
--- a/ansible/roles/illumidesk/tasks/main.yml
+++ b/ansible/roles/illumidesk/tasks/main.yml
@@ -5,6 +5,7 @@
     dest: "{{ working_dir }}"
     rsync_opts:
       - "--no-motd"
+      - "--exclude=.git"
       - "--exclude=.pyc"
       - "--exclude=__pycache__"
 

--- a/ansible/roles/illumidesk/tasks/main.yml
+++ b/ansible/roles/illumidesk/tasks/main.yml
@@ -5,8 +5,9 @@
     dest: "{{ working_dir }}"
     rsync_opts:
       - "--no-motd"
-      - "--exclude=.git"
-      - "--exclude=.pyc"
+      - "--exclude=build*"
+      - "--exclude=*.egg-info"
+      - "--exclude=*.pyc"
       - "--exclude=__pycache__"
 
 - name: create a zip archive of the illumidesk package


### PR DESCRIPTION
Ignore `.git`, `*.egg-info` and `build*` folders.