### PR TITLE
Adds helper text in the assignment creation modal

### DIFF
--- a/ansible/roles/nbgrader/files/server_extensions/formgrader/static/js/manage_assignments.js
+++ b/ansible/roles/nbgrader/files/server_extensions/formgrader/static/js/manage_assignments.js
@@ -583,6 +583,8 @@ var createAssignmentModal = function () {
 
     var body = $("<p/>")
     body.append($("<p id='create-error' class='alert alert-danger' style='display: none'/>"));
+    body.append($("<p id='create-error' class='alert alert-warning'/>").text("Please add an assignment name that only lower case characters. Refrain from using spaces and special characters. This name should be the same as the assignment name registered with the assignment name in your LMS."));
+    
     var table = $("<table/>").addClass("table table-striped form-table");
     body.append(table)
     var name = $("<tr/>");


### PR DESCRIPTION
In order to avoid assignment name conflicts when it contains spaces or other characters, we're showing a text to help user in the assignment creation.

<img width="973" alt="Screen Shot 2020-05-11 at 17 20 23" src="https://user-images.githubusercontent.com/2465401/81617821-be52a780-93ab-11ea-8147-99adc97f2b83.png">
