### PR TITLE
Do not use initial course service when LTI is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,10 +334,6 @@ The services included with this setup rely on environment variables to work prop
 | Variable  |  Type | Description | Default Value |
 |---|---|---|---|
 | COURSE_ID | `string` | Demo course id, equivalent to course name or course label. | `intro101` |
-| DEMO_INSTRUCTOR_NAME | `string` | Demo instructor user name. | `instructor1` |
-| DEMO_INSTRUCTOR_GROUP | `string` | Demo instructor group name. | `formgrade-{course_id}` |
-| DEMO_STUDENT_GROUP | `string` | Demo student group name. | `nbgrader-{course_id}` |
-| DEMO_GRADER_NAME | `string` | Demo grader service name. | `service-{course_id}` |
 | DOCKER_LEARNER_IMAGE | `string` | Docker image used by users with the Learner role. | `illumidesk/notebook:learner` |
 | DOCKER_GRADER_IMAGE | `string` | Docker image used by users with the Grader role. | `illumidesk/notebook:grader` |
 | DOCKER_INSTRUCTOR_IMAGE | `string` | Docker image used by users with the Instructor role. | `illumidesk/notebook:instructor` |
@@ -362,6 +358,8 @@ The services included with this setup rely on environment variables to work prop
 | POSTGRES_HOST | `string` | Postgres host | `jupyterhub-db` |
 
 ### Environment Variables pertaining to grader service, located in `env.service`
+
+> This file is only used when you're using the initial setup with FirstUseAuthenticator
 
 | Variable  |  Type | Description | Default Value |
 |---|---|---|---|

--- a/README.md
+++ b/README.md
@@ -334,6 +334,10 @@ The services included with this setup rely on environment variables to work prop
 | Variable  |  Type | Description | Default Value |
 |---|---|---|---|
 | COURSE_ID | `string` | Demo course id, equivalent to course name or course label. | `intro101` |
+| DEMO_INSTRUCTOR_NAME | `string` | Demo instructor user name. | `instructor1` |
+| DEMO_INSTRUCTOR_GROUP | `string` | Demo instructor group name. | `formgrade-{course_id}` |
+| DEMO_STUDENT_GROUP | `string` | Demo student group name. | `nbgrader-{course_id}` |
+| DEMO_GRADER_NAME | `string` | Demo grader service name. | `service-{course_id}` |
 | DOCKER_LEARNER_IMAGE | `string` | Docker image used by users with the Learner role. | `illumidesk/notebook:learner` |
 | DOCKER_GRADER_IMAGE | `string` | Docker image used by users with the Grader role. | `illumidesk/notebook:grader` |
 | DOCKER_INSTRUCTOR_IMAGE | `string` | Docker image used by users with the Instructor role. | `illumidesk/notebook:instructor` |

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
@@ -43,34 +43,12 @@ data_dir = '/data'
 
 c.JupyterHub.cookie_secret_file = os.path.join(data_dir, 'jupyterhub_cookie_secret')
 
-# The instructor1 and instructor2 users have access to different shared
-# grader notebooks. bitdiddle, hacker, and reasoner students are from
-# the `nbgrader quickstart <course name>` command.
-c.JupyterHub.load_groups = {
-    os.environ.get('DEMO_INSTRUCTOR_GROUP'): [
-        'instructor1',
-        'instructor2',
-        os.environ.get('DEMO_GRADER_NAME'),
-    ],  # noqa: E231
-    os.environ.get('DEMO_STUDENT_GROUP'): ['student1', 'bitdiddle', 'hacker', 'reasoner',],  # noqa: E231
-}
-
 # Allow admin access to end-user notebooks
 c.JupyterHub.admin_access = True
 
-# Start the grader notebook as a service. The port can be whatever you want
-# and the group has to match the name of the DEMO_GRADER_NAME group defined above.
-# The cull_idle service conserves resources.
-course_id = os.environ.get('COURSE_ID')
+# Define some static services that jupyterhub will manage
 announcement_port = os.environ.get("ANNOUNCEMENT_SERVICE_PORT") or '8889'
 c.JupyterHub.services = [
-    {
-        'name': os.environ.get('COURSE_ID'),
-        'url': f'http://{course_id}:8888',
-        'oauth_no_confirm': True,
-        'admin': True,
-        'api_token': os.environ.get('JUPYTERHUB_API_TOKEN'),
-    },
     {
         'name': 'cull_idle',
         'admin': True,
@@ -155,7 +133,6 @@ c.LTIAuthenticator.consumers = {
 # Add other admin users as needed
 c.Authenticator.admin_users = {
     'admin',
-    os.environ.get('DEMO_INSTRUCTOR_NAME'),
 }
 
 # If using an authenticator which requires additional logic,

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
@@ -47,7 +47,7 @@ c.JupyterHub.cookie_secret_file = os.path.join(data_dir, 'jupyterhub_cookie_secr
 c.JupyterHub.admin_access = True
 
 # Define some static services that jupyterhub will manage
-announcement_port = os.environ.get("ANNOUNCEMENT_SERVICE_PORT") or '8889'
+announcement_port = os.environ.get('ANNOUNCEMENT_SERVICE_PORT') or '8889'
 c.JupyterHub.services = [
     {
         'name': 'cull_idle',

--- a/ansible/roles/jupyterhub/tasks/main.yml
+++ b/ansible/roles/jupyterhub/tasks/main.yml
@@ -96,6 +96,7 @@
   template:
     src: env.service.j2
     dest: "{{ working_dir }}/env.service"
+  when: not lti11_enabled|bool
 
 - name: create the jupyterhub env var file from template
   template:

--- a/ansible/roles/jupyterhub/templates/docker-compose.yml.j2
+++ b/ansible/roles/jupyterhub/templates/docker-compose.yml.j2
@@ -38,7 +38,8 @@ services:
     volumes:
       - ./reverse-proxy/:/etc/traefik/
       - /var/run/docker.sock:/var/run/docker.sock
-    restart: on-failure    
+    restart: on-failure
+{% if lti11_enabled is sameas false %}
   {{course_id}}:
     restart: on-failure
     image: {{docker_illumidesk_notebook_grader_image}}
@@ -51,6 +52,7 @@ services:
       - env.service
     command: >
       start-notebook.sh --group=formgrade-{{course_id}} --allow-root
+{% endif %}
   setup-course:
     restart: on-failure
     image: {{docker_setup_course_image}}

--- a/ansible/roles/jupyterhub/templates/env.jhub.j2
+++ b/ansible/roles/jupyterhub/templates/env.jhub.j2
@@ -28,11 +28,13 @@ JUPYTERHUB_API_TOKEN_USER=grader-{{course_id}}
 # external facing api url
 JUPYTERHUB_API_URL=http://reverse-proxy:8000/hub/api
 
+{% if lti11_enabled is sameas false %}
 # demo course/group values, useful for when not using LTI
 DEMO_GRADER_NAME=grader-{{course_id}}
 DEMO_INSTRUCTOR_NAME=instructor1
 DEMO_INSTRUCTOR_GROUP=formgrade-{{course_id}}
 DEMO_STUDENT_GROUP=nbgrader-{{course_id}}
+{% endif %}
 
 # organization name used with nfs
 ORGANIZATION_NAME={{org_name}}


### PR DESCRIPTION
- remove course definition from docker-compose and jupyterhub_config_lti11.py
- remove user groups
- do not copy the *env.service* file
- remove some vars in env.jhub related to initial course