### PR TITLE
Add missing setup-course dependencies

### DIFF
--- a/ansible/roles/setup_course/files/Dockerfile
+++ b/ansible/roles/setup_course/files/Dockerfile
@@ -9,10 +9,12 @@ RUN apk update \
 
 RUN apk update \
  && apk add --no-cache \
+ g++ \
  gcc \
  libc-dev \
  libffi-dev \
  libressl-dev \
+ libxslt-dev \
  linux-headers \
  make \
  musl-dev \


### PR DESCRIPTION
Builds are failing with setup-course image due to the lack of `libxslt-dev` and `g++`.