### PR TITLE
Revert ansible to 2.9.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible==2.9.10
+ansible==2.9.9


### PR DESCRIPTION
The update to ansible `2.9.10` isn't valid, so reverting to `2.9.9`.