### PR TITLE
Feature to add a postgres service for labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ By default, this setup uses the `FirstUseAuthenticator` and as such accepts any 
 
 * **Data Directories**: This repo uses `docker-compose` to start all services and data volumes for JupyterHub, notebook directories, databases, and the `nbgrader exchange` directory using mounts from the host's file system.
 
-* **Databases**: This setup relies on a standard `Postgres` database running in its own container.
+* **Databases**: This setup relies on a standard `postgres` database running in its own container for the JupyterHub application and another separate and optional Postgres database for lab environments (useful to connect from user notebooks).
 
 * **Network**: An external bridge network named `jupyter-network` is used by default. The grader service and the user notebooks are attached to this network.
 
@@ -390,23 +390,6 @@ The services included with this setup rely on environment variables to work prop
 | NB_GID | `string` | Notebook grader user id | `100` |
 
 ---
-
-### Databases
-
-This setup relies on a standard Postgres database running in its own container for the JupyterHub application and another separate and optional Postgres database for lab environments (internally named as `postgres-labs`).
-
-You can connect with the second postgres instance (from notebooks) by using the next variables:
-
-POSTGRES_DB=labs
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-
-For example:
-
-```python
-import psycopg2
-conn = psycopg2.connect(host="postgres-labs", database="labs", user="postgres", password="postgres")
-```
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -391,6 +391,23 @@ The services included with this setup rely on environment variables to work prop
 
 ---
 
+### Databases
+
+This setup relies on a standard Postgres database running in its own container for the JupyterHub application and another separate and optional Postgres database for lab environments (internally named as `postgres-labs`).
+
+You can connect with the second postgres instance (from notebooks) by using the next variables:
+
+POSTGRES_DB=labs
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+
+For example:
+
+```python
+import psycopg2
+conn = psycopg2.connect(host="postgres-labs", database="labs", user="postgres", password="postgres")
+```
+
 ## Resources
 
 ### Documentation

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -52,3 +52,4 @@ lti11_consumer_key: "{{ lti11_consumer_key_result }}"
 lti11_shared_secret: "{{ lti11_shared_secret_result }}"
 
 lti11_enabled: "{{ lti11_enabled_param | default('false')}}"
+postgres_labs_enabled: "{{ postgres_labs_enabled_param | default('false') }}"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -52,4 +52,5 @@ lti11_consumer_key: "{{ lti11_consumer_key_result }}"
 lti11_shared_secret: "{{ lti11_shared_secret_result }}"
 
 lti11_enabled: "{{ lti11_enabled_param | default('false')}}"
+# Postgres for notebooks labs
 postgres_labs_enabled: "{{ postgres_labs_enabled_param | default('false') }}"

--- a/ansible/hosts.hddata
+++ b/ansible/hosts.hddata
@@ -1,0 +1,36 @@
+all:
+  hosts:
+    illumidesk:
+      ## Required settings
+      #-------------------
+      ansible_host: 18.236.148.33
+      ansible_port: 22
+      ansible_user: ubuntu
+      ansible_ssh_private_key_file: ~/Documents/3blades/illumidesk/aws/ubuntu-lab-12-19.pem
+
+      # add a password only if your remote instance uses userid/password for SSH authentication
+      ansible_password:
+
+      ## Optional settings
+      #-------------------
+      # organization name, also used for the sub-domain, such as acme
+      org_name: hddata
+
+      # top level domain, such as example.com
+      tld: illumidesk.com
+
+      # course label, such as finance101
+      course_id: course101
+
+      # lti 1.1 consumer key, by default this is set dynamically. add
+      # own value to override setting. we recommend using the openssl
+      # command to create secure strings: openssl rand -hex 16 
+      lti11_consumer_key: hddata_consumer_key
+
+      # lti 1.1 shared secret, by default set dynamically. set to at 
+      # least 32 random bytes: openssl rand -hex 32
+      lti11_shared_secret: hddata_shared_secret
+
+      # set to yes to use LTI 1.1
+      lti11_enabled: true
+      mnt_root: /mnt/efs/fs1

--- a/ansible/roles/jupyterhub/tasks/main.yml
+++ b/ansible/roles/jupyterhub/tasks/main.yml
@@ -3,6 +3,10 @@
   docker_volume:
     name: db-data
 
+- name: create external postgres data volume for notebooks labs
+  docker_volume:
+    name: db-labs-data
+
 - name: create external jupyterhub and setup-course data volume
   docker_volume:
     name: jupyterhub-data

--- a/ansible/roles/jupyterhub/templates/docker-compose.yml.j2
+++ b/ansible/roles/jupyterhub/templates/docker-compose.yml.j2
@@ -65,6 +65,18 @@ services:
       - {{mnt_root}}:{{mnt_root}}
       - data:/srv/jupyterhub
       - {{ working_dir }}:{{ working_dir }}
+{% if postgres_labs_enabled is sameas true %}
+  postgres-labs:
+    image: postgres:11.6-alpine
+    container_name: postgres-labs
+    restart: always
+    environment:
+      - POSTGRES_DB=labs
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    volumes:
+      - db-labs:/var/lib/postgresql/data
+{% endif %}
 
 volumes:
   data:
@@ -73,6 +85,9 @@ volumes:
   db:
     external:
       name: db-data
+  db-labs:
+    external:
+      name: db-labs-data
   
 networks:
   default:

--- a/ansible/roles/notebooks/files/requirements.txt
+++ b/ansible/roles/notebooks/files/requirements.txt
@@ -9,6 +9,6 @@ jupyter-contrib-nbextensions==0.5
 plotly==4.7.1
 plotly-charts==0.5
 plotly-geo==1.0
+psycopg2-binary==2.8.5
 yellowbrick==1.1
 widgetsnbextension
-psycopg2-binary==2.8.5

--- a/ansible/roles/notebooks/files/requirements.txt
+++ b/ansible/roles/notebooks/files/requirements.txt
@@ -11,3 +11,4 @@ plotly-charts==0.5
 plotly-geo==1.0
 yellowbrick==1.1
 widgetsnbextension
+psycopg2-binary==2.8.5


### PR DESCRIPTION
- add postgres dependency for notebooks
- add new service definition in docker-compose
- add new ansible flag to indicate when to use this service 

How to use with python:

`import psycopg2`
`conn = psycopg2.connect(host="postgres-labs", database="labs", user="postgres", password="postgres")`