### PR TITLE
Add tests and update docs for missing environment variable used with rolling updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ The services included with this setup rely on environment variables to work prop
 |---|---|---|---|
 | DOCKER_NETWORK_NAME | `string` | JupyterHub API token | `jupyter-network` |
 | GRADER_SERVICE_IMAGE | `string` | External facing API URL | `http://reverse-proxy:8000/hub/api` |
-| ILLUMIDESK_DIR | `string` | IllumiDesk working directory | `illumidesk_deployment` |
+| ILLUMIDESK_DIR | `string` | IllumiDesk working directory | `/home/ubuntu/illumidesk_deployment` |
 | JUPYTERHUB_API_TOKEN | `string` | API token to connect with the JupyterHub | `<random value>` |
 | JUPYTERHUB_API_URL | `string` | JupyterHub client id used with OAuth2 | `http://reverse-proxy:8000/hub/api` |
 | JUPYTERHUB_CONFIG_PATH | `string` | Notebook grader user | `/srv/jupyterhub` |

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ The services included with this setup rely on environment variables to work prop
 |---|---|---|---|
 | DOCKER_NETWORK_NAME | `string` | JupyterHub API token | `jupyter-network` |
 | GRADER_SERVICE_IMAGE | `string` | External facing API URL | `http://reverse-proxy:8000/hub/api` |
-| ILLUMIDESK_DIR | `string` | IllumiDesk working directory | `/home/ubuntu/illumidesk_deployment` |
+| ILLUMIDESK_DIR | `string` | IllumiDesk working directory within remote user's home directory | `$HOME/illumidesk_deployment` |
 | JUPYTERHUB_API_TOKEN | `string` | API token to connect with the JupyterHub | `<random value>` |
 | JUPYTERHUB_API_URL | `string` | JupyterHub client id used with OAuth2 | `http://reverse-proxy:8000/hub/api` |
 | JUPYTERHUB_CONFIG_PATH | `string` | Notebook grader user | `/srv/jupyterhub` |

--- a/ansible/hosts.example
+++ b/ansible/hosts.example
@@ -21,8 +21,7 @@ all:
 
       ## (Optional) Endpoint/namespace settings
       #-------------------
-      # uncomment to add your organization name, also used for the sub-domain, 
-      # such as acme
+      # uncomment to add your organization name, defaults to my-org.
       # org_name: my-org
 
       # uncomment to add top level domain, such as example.com

--- a/ansible/hosts.example
+++ b/ansible/hosts.example
@@ -15,19 +15,21 @@ all:
       # IPv4 host address
       ansible_ssh_private_key_file: /path/to/my/key/file
 
-      # add a password only if your remote instance uses userid/password for SSH authentication
-      ansible_password:
+      # uncomment and add a password only if your remote instance uses userid/password 
+      # for SSH authentication
+      # ansible_password: my-secret-password
 
       ## (Optional) Endpoint/namespace settings
       #-------------------
-      # organization name, also used for the sub-domain, such as acme
-      org_name:
+      # uncomment to add your organization name, also used for the sub-domain, 
+      # such as acme
+      # org_name: my-org
 
-      # top level domain, such as example.com
-      tld:
+      # uncomment to add top level domain, such as example.com
+      # tld: example.com
 
-      # course label, such as finance101
-      course_id:
+      # uncomment to add your custom course name, such as finance101
+      # course_id: intro101
 
       ## Authentication settings
       #-------------------
@@ -41,30 +43,36 @@ all:
       #-------------------
 
       # set to true to use LTI 1.1. If true, set lti13_enabled to false.
-      lti11_enabled: false
+      # lti11_enabled: false
 
       # lti 1.1 consumer key, by default this is set dynamically. add
       # own value to override setting. we recommend using the openssl
       # command to create secure strings: e.g. `openssl rand -hex 16` 
-      lti11_consumer_key:
+      # lti11_consumer_key:
 
       # lti 1.1 shared secret, by default set dynamically. set to at 
       # least 32 random bytes: e.g. `openssl rand -hex 32`
-      lti11_shared_secret:
+      # lti11_shared_secret:
 
       ### LTI 1.3
       #-------------------
       
       # set to true to use LTI 1.3. If true, set lti11_enabled to false.
-      lti13_enabled: false
+      # lti13_enabled: false
       
       # private key path and file name (pem)
-      lti13_private_key: /secrets/keys/rsa_private.pem
+      # lti13_private_key: /secrets/keys/rsa_private.pem
 
-      # the client id which represents the tools installation on the platform
-      lti13_client_id: 
+      # the client id which represents the tools installation on the platform. the
+      # example below is an example clint id displayed by the details column in developer
+      # keys from the canvas lms.
+      # lti13_client_id: 125900000000000001
       
-      # lti 1.3 urls/endpoints
-      lti13_endpoint: 
-      lti13_token_url: 
-      lti13_authorize_url: 
+      # lti 1.3 urls/endpoints, the ones provided below are example endpoints
+      # used with the canvas lms.
+      # lti13_private_key: /secrets/keys/rsa_private.pem
+      # lti13_endpoint: https://illumidesk.instructure.com/api/lti/security/jwks
+      # lti13_token_url: https://illumidesk.instructure.com/login/oauth2/token
+      # lti13_authorize_url: https://illumidesk.instructure.com/api/lti/authorize_redirect
+
+      

--- a/ansible/roles/setup_course/templates/env.setup_course.j2
+++ b/ansible/roles/setup_course/templates/env.setup_course.j2
@@ -3,6 +3,9 @@ DOCKER_NETWORK_NAME=jupyter-network
 # grader service image
 GRADER_SERVICE_IMAGE={{docker_illumidesk_notebook_grader_image}}
 
+# deployment working directory
+ILLUMIDESK_DIR={{working_dir}}
+
 # api token should be equal to value set for jupyterhub
 JUPYTERHUB_API_TOKEN={{jhub_api_token}}
 

--- a/src/illumidesk/setup_course/app.py
+++ b/src/illumidesk/setup_course/app.py
@@ -1,8 +1,8 @@
+import asyncio
 import json
 import logging
 import os
 import sys
-import asyncio
 
 from filelock import FileLock
 from pathlib import Path
@@ -10,6 +10,7 @@ from pathlib import Path
 from quart import Quart
 from quart import request
 from quart.exceptions import BadRequest
+
 from .course import Course
 from .utils import SetupUtils
 

--- a/src/illumidesk/setup_course/utils.py
+++ b/src/illumidesk/setup_course/utils.py
@@ -21,8 +21,8 @@ class SetupUtils:
         self.docker_client = docker.from_env()
         self.jupyterhub_container_name = os.environ.get('JUPYTERHUB_SERVICE_NAME') or 'jupyterhub'
         self.illumidesk_dir = os.environ.get('ILLUMIDESK_DIR')
-        if self.illumidesk_dir == '' or self.illumidesk_dir is None:
-            raise TypeError('Missing or null ILLUMIDESK_DIR env var value.')
+        if not self.illumidesk_dir:
+            raise EnvironmentError('Missing or null ILLUMIDESK_DIR env var value.')
 
     def restart_jupyterhub(self) -> None:
         """

--- a/src/illumidesk/setup_course/utils.py
+++ b/src/illumidesk/setup_course/utils.py
@@ -1,9 +1,12 @@
 import os
-import sys
 import logging
-import docker
 import subprocess
+import sys
 import time
+
+import docker
+from docker.errors import NotFound
+
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -16,6 +19,10 @@ class SetupUtils:
 
     def __init__(self):
         self.docker_client = docker.from_env()
+        self.jupyterhub_container_name = os.environ.get('JUPYTERHUB_SERVICE_NAME') or 'jupyterhub'
+        self.illumidesk_dir = os.environ.get('ILLUMIDESK_DIR')
+        if self.illumidesk_dir == '' or self.illumidesk_dir is None:
+            raise TypeError('Missing or null ILLUMIDESK_DIR env var value.')
 
     def restart_jupyterhub(self) -> None:
         """
@@ -24,11 +31,8 @@ class SetupUtils:
         Traefik can redirect the traffic to new one service few seconds later.
         """
         logger.debug('Received request to restart JupyterHub')
-        jupyterhub_container_name = os.environ.get('JUPYTERHUB_SERVICE_NAME') or 'jupyterhub'
-        illumidesk_dir = os.environ.get('ILLUMIDESK_DIR') or '/home/ubuntu/illumidesk_deployment'
-
         containers = self.docker_client.containers.list(
-            filters={'label': [f'com.docker.compose.service={jupyterhub_container_name}']}
+            filters={'label': [f'com.docker.compose.service={self.jupyterhub_container_name}']}
         )
         for container in containers:
             logger.debug(f'Found a jupyterhub container (running): {container.id}')
@@ -36,19 +40,19 @@ class SetupUtils:
                 # launch a new one to be attached in the proxy
                 logger.info('Trying to scale jupyterhub with docker-compose')
                 subprocess.check_output(
-                    f'docker-compose --compatibility up -d --scale {jupyterhub_container_name}=2'.split(),
-                    cwd=f'{illumidesk_dir}',
+                    f'docker-compose --compatibility up -d --scale {self.jupyterhub_container_name}=2'.split(),
+                    cwd=f'{self.illumidesk_dir}',
                 )
-
                 time.sleep(3)
                 logger.debug(f'The container: {container.id} is stopping...')
                 container.stop()
                 time.sleep(1)
-            except docker.errors.NotFound:
-                logger.error('Jupyterhub container not found to be stopped')
+            except NotFound:
+                logger.error('Jupyterhub container not found, unable to proceed with rolling update.')
             except Exception as er:
-                logger.error(f'Error trying to scale jupyterhub. {er}')
+                logger.error(f'Error trying to scale jupyterhub: {er}')
             break
         self.docker_client.containers.prune(
-            filters={'label': [f'com.docker.compose.service={jupyterhub_container_name}']}
+            filters={'label': [f'com.docker.compose.service={self.jupyterhub_container_name}']}
         )
+        logger.debug(f'Pruning unused jupyterhub containers {self.jupyterhub_container_name}')

--- a/src/illumidesk/setup_course/utils.py
+++ b/src/illumidesk/setup_course/utils.py
@@ -25,7 +25,7 @@ class SetupUtils:
         """
         logger.debug('Received request to restart JupyterHub')
         jupyterhub_container_name = os.environ.get('JUPYTERHUB_SERVICE_NAME') or 'jupyterhub'
-        illumidesk_dir = os.environ.get('ILLUMIDESK_DIR') or '/home/ubuntu/'
+        illumidesk_dir = os.environ.get('ILLUMIDESK_DIR') or '/home/ubuntu/illumidesk_deployment'
 
         containers = self.docker_client.containers.list(
             filters={'label': [f'com.docker.compose.service={jupyterhub_container_name}']}

--- a/src/illumidesk/tests/conftest.py
+++ b/src/illumidesk/tests/conftest.py
@@ -1,1 +1,71 @@
-# add pytest fixtures here
+import pytest
+
+from docker.errors import NotFound
+
+from unittest.mock import Mock
+from unittest.mock import MagicMock
+
+
+@pytest.fixture(scope="function")
+def setup_course_environ(monkeypatch, tmp_path):
+    """
+    Set the environment variables used in Course class
+    """
+    monkeypatch.setenv('MNT_ROOT', str(tmp_path))
+    monkeypatch.setenv('NB_UID', '10001')
+    monkeypatch.setenv('NB_GID', '100')
+
+
+@pytest.fixture(scope="function")
+def setup_utils_environ(monkeypatch, tmp_path):
+    """
+    Set the enviroment variables used in SetupUtils class
+    """
+    monkeypatch.setenv('JUPYTERHUB_SERVICE_NAME', 'jupyterhub')
+    monkeypatch.setenv('ILLUMIDESK_DIR', '/home/foo/illumidesk_deployment')
+
+
+@pytest.fixture(scope="function")
+def setup_utils_environ_empty_illumidesk_dir(monkeypatch, tmp_path):
+    """
+    Set the enviroment variables used in SetupUtils class
+    """
+    monkeypatch.setenv('JUPYTERHUB_SERVICE_NAME', 'jupyterhub')
+    monkeypatch.setenv('ILLUMIDESK_DIR', '')
+
+
+@pytest.fixture(scope="function")
+def docker_containers():
+    """
+    Creates a DockerClient mock object
+    """
+    docker_client = Mock(spec='docker.DockerClient')
+
+    def _container_not_exists(name):
+        raise NotFound(f'container: {name} not exists')
+
+    docker_client.containers = MagicMock()
+    docker_client.containers.get.side_effect = lambda name: _container_not_exists(name)
+
+
+@pytest.fixture(scope="function")
+def setup_course_environ(monkeypatch, tmp_path):
+    """
+    Set the enviroment variables used in Course class
+    """
+    monkeypatch.setenv('MNT_ROOT', str(tmp_path))
+    monkeypatch.setenv('NB_UID', '10001')
+    monkeypatch.setenv('NB_GID', '100')
+
+
+@pytest.fixture(scope='function')
+def test_client(monkeypatch, tmp_path):
+    """
+    Before to import the quart-app we define the env-vars required
+    """
+    monkeypatch.setenv('JUPYTERHUB_CONFIG_PATH', str(tmp_path))
+    # important than environ reads JUPYTERHUB_CONFIG_PATH variable before
+    # app initialization
+    from illumidesk.setup_course.app import app
+
+    return app.test_client()

--- a/src/illumidesk/tests/conftest.py
+++ b/src/illumidesk/tests/conftest.py
@@ -35,7 +35,7 @@ def setup_utils_environ_empty_illumidesk_dir(monkeypatch, tmp_path):
 
 
 @pytest.fixture(scope="function")
-def docker_containers():
+def mock_docker_client_cotainers_not_found():
     """
     Creates a DockerClient mock object
     """
@@ -46,16 +46,6 @@ def docker_containers():
 
     docker_client.containers = MagicMock()
     docker_client.containers.get.side_effect = lambda name: _container_not_exists(name)
-
-
-@pytest.fixture(scope="function")
-def setup_course_environ(monkeypatch, tmp_path):
-    """
-    Set the enviroment variables used in Course class
-    """
-    monkeypatch.setenv('MNT_ROOT', str(tmp_path))
-    monkeypatch.setenv('NB_UID', '10001')
-    monkeypatch.setenv('NB_GID', '100')
 
 
 @pytest.fixture(scope='function')

--- a/src/illumidesk/tests/illumidesk/setup_course/test_app.py
+++ b/src/illumidesk/tests/illumidesk/setup_course/test_app.py
@@ -1,30 +1,10 @@
 import json
+
 import pytest
+
 from unittest.mock import patch, MagicMock
+
 from illumidesk.setup_course.course import Course
-
-
-@pytest.fixture(scope="function")
-def setup_course_environ(monkeypatch, tmp_path):
-    """
-    Set the enviroment variables used in Course class
-    """
-    monkeypatch.setenv('MNT_ROOT', str(tmp_path))
-    monkeypatch.setenv('NB_UID', '10001')
-    monkeypatch.setenv('NB_GID', '100')
-
-
-@pytest.fixture(scope='function')
-def test_client(monkeypatch, tmp_path):
-    """
-    Before to import the quart-app we define the env-vars required
-    """
-    monkeypatch.setenv('JUPYTERHUB_CONFIG_PATH', str(tmp_path))
-    # important than environ reads JUPYTERHUB_CONFIG_PATH variable before
-    # app initialization
-    from illumidesk.setup_course.app import app
-
-    return app.test_client()
 
 
 @pytest.mark.asyncio

--- a/src/illumidesk/tests/illumidesk/setup_course/test_course.py
+++ b/src/illumidesk/tests/illumidesk/setup_course/test_course.py
@@ -1,109 +1,89 @@
 import os
 from pathlib import Path
+
 import pytest
+
 from unittest.mock import patch
-from unittest.mock import Mock, MagicMock
+
 from docker.errors import NotFound
+
 from illumidesk.setup_course.course import Course
-
-
-@pytest.fixture(scope="function")
-def setup_environ(monkeypatch, tmp_path):
-    """
-    Set the environment variables used in Course class
-    """
-    monkeypatch.setenv('MNT_ROOT', str(tmp_path))
-    monkeypatch.setenv('NB_UID', '10001')
-    monkeypatch.setenv('NB_GID', '100')
-
-
-@pytest.fixture(scope="function")
-def docker_containers():
-    """
-    Creates a DockerClient mock object
-    """
-    docker_client = Mock(spec='docker.DockerClient')
-
-    def _container_not_exists(name):
-        raise NotFound(f'container: {name} not exists')
-
-    docker_client.containers = MagicMock()
-    docker_client.containers.get.side_effect = lambda name: _container_not_exists(name)
 
 
 def test_initializer_requires_arguments():
     """
-    is it posible to create a new Course without any argument?
+    Do we get a type error if we try to create a course instance without all required initialization
+    variables?
     """
     with pytest.raises(TypeError):
         Course()
 
 
-def test_initializer_set_course_id(setup_environ):
+def test_initializer_set_course_id(setup_course_environ):
     """
-    does the initializer set course_id property?
+    Does the initializer properly set the course_id property?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
     assert course.course_id is not None
     assert course.course_id == 'example'
 
 
-def test_initializer_set_org(setup_environ):
+def test_initializer_set_org(setup_course_environ):
     """
-    does the initializer set org property?
+    Does the initializer properly set the organization property?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
     assert course.org is not None
     assert course.org == 'org1'
 
 
-def test_initializer_set_domain(setup_environ):
+def test_initializer_set_domain(setup_course_environ):
     """
-    does the initializer set domain property?
+    Does the initializer properly set the domain property?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
     assert course.domain is not None
     assert course.domain == 'example.com'
 
 
-def test_grader_name_is_correct(setup_environ):
+def test_grader_name_is_correct(setup_course_environ):
     """
-    is the grader_name well formed?
+    Is the grader_name well formed?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
     assert course.grader_name is not None
     assert course.grader_name == f'grader-{course.course_id}'
 
 
-def test_grader_root_path_is_valid(setup_environ):
+def test_grader_root_path_is_valid(setup_course_environ):
     """
-    is the grader_root well formed?
+    Is the grader_root well formed?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
     assert course.grader_root is not None
     assert course.grader_root == Path(os.environ.get('MNT_ROOT'), course.org, 'home', course.grader_name,)
 
 
-def test_course_path_is_a_grader_root_subfolder(setup_environ):
+def test_course_path_is_a_grader_root_subfolder(setup_course_environ):
     """
-    is the course path a grader subfolder?
+    Is the course path a grader subfolder?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
     assert course.course_root is not None
     assert course.course_root == Path(course.grader_root, course.course_id)
 
 
-def test_new_course_has_a_token(setup_environ):
+def test_new_course_has_a_token(setup_course_environ):
     """
-    does the initializer set token property?
+    Does the initializer set token property?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
     assert course.token is not None
 
 
-def test_a_course_contains_service_config_well_formed(setup_environ):
+def test_a_course_contains_service_config_well_formed(setup_course_environ):
     """
-    does the get_service_config method return a valid config?
+    Does the get_service_config method return a valid config?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
     service_config = course.get_service_config()
@@ -114,9 +94,9 @@ def test_a_course_contains_service_config_well_formed(setup_environ):
     assert 'api_token' in service_config
 
 
-def test_a_course_contains_service_config_with_correct_values(setup_environ):
+def test_a_course_contains_service_config_with_correct_values(setup_course_environ):
     """
-    does the get_service_config method return a config with valid values?
+    Does the get_service_config method return a config with valid values?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
     service_config = course.get_service_config()
@@ -127,9 +107,9 @@ def test_a_course_contains_service_config_with_correct_values(setup_environ):
 
 
 @patch('docker.DockerClient.containers')
-def test_should_setup_method_returns_true_if_container_does_not_exist(mock_docker, setup_environ):
+def test_should_setup_method_returns_true_if_container_does_not_exist(mock_docker, setup_course_environ):
     """
-    does the should_setup method return True when the container not was found?
+    Does the should_setup method return True when the container not was found?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
 
@@ -140,9 +120,9 @@ def test_should_setup_method_returns_true_if_container_does_not_exist(mock_docke
     assert course.should_setup() is True
 
 
-def test_course_exchange_root_directory_is_created(setup_environ, docker_containers):
+def test_course_exchange_root_directory_is_created(setup_course_environ, docker_containers):
     """
-    is the exchange directory created as part of setup?
+    Is the exchange directory created as part of setup?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
     with patch('shutil.chown', autospec=True):
@@ -150,9 +130,9 @@ def test_course_exchange_root_directory_is_created(setup_environ, docker_contain
         assert course.exchange_root.exists()
 
 
-def test_course_root_directory_is_created(setup_environ, docker_containers):
+def test_course_root_directory_is_created(setup_course_environ, docker_containers):
     """
-    is the course directory created as part of setup?
+    Is the course directory created as part of setup?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
     with patch('shutil.chown', autospec=True):
@@ -160,9 +140,9 @@ def test_course_root_directory_is_created(setup_environ, docker_containers):
         assert course.course_root.exists()
 
 
-def test_course_jupyter_config_path_is_created(setup_environ, docker_containers):
+def test_course_jupyter_config_path_is_created(setup_course_environ, docker_containers):
     """
-    is the jupyter config directory created as part of setup?
+    Is the jupyter config directory created as part of setup?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
     with patch('shutil.chown', autospec=True):
@@ -170,9 +150,9 @@ def test_course_jupyter_config_path_is_created(setup_environ, docker_containers)
         assert course.jupyter_config_path.exists()
 
 
-def test_course_nbgrader_config_path_is_created(setup_environ, docker_containers):
+def test_course_nbgrader_config_path_is_created(setup_course_environ, docker_containers):
     """
-    is the nbgrader directory created as part of setup?
+    Is the nbgrader directory created as part of setup?
     """
     course = Course(org='org1', course_id='example', domain='example.com')
     with patch('shutil.chown', autospec=True):

--- a/src/illumidesk/tests/illumidesk/setup_course/test_course.py
+++ b/src/illumidesk/tests/illumidesk/setup_course/test_course.py
@@ -120,7 +120,7 @@ def test_should_setup_method_returns_true_if_container_does_not_exist(mock_docke
     assert course.should_setup() is True
 
 
-def test_course_exchange_root_directory_is_created(setup_course_environ, docker_containers):
+def test_course_exchange_root_directory_is_created(setup_course_environ, mock_docker_client_cotainers_not_found):
     """
     Is the exchange directory created as part of setup?
     """
@@ -130,7 +130,7 @@ def test_course_exchange_root_directory_is_created(setup_course_environ, docker_
         assert course.exchange_root.exists()
 
 
-def test_course_root_directory_is_created(setup_course_environ, docker_containers):
+def test_course_root_directory_is_created(setup_course_environ, mock_docker_client_cotainers_not_found):
     """
     Is the course directory created as part of setup?
     """
@@ -140,7 +140,7 @@ def test_course_root_directory_is_created(setup_course_environ, docker_container
         assert course.course_root.exists()
 
 
-def test_course_jupyter_config_path_is_created(setup_course_environ, docker_containers):
+def test_course_jupyter_config_path_is_created(setup_course_environ, mock_docker_client_cotainers_not_found):
     """
     Is the jupyter config directory created as part of setup?
     """
@@ -150,7 +150,7 @@ def test_course_jupyter_config_path_is_created(setup_course_environ, docker_cont
         assert course.jupyter_config_path.exists()
 
 
-def test_course_nbgrader_config_path_is_created(setup_course_environ, docker_containers):
+def test_course_nbgrader_config_path_is_created(setup_course_environ, mock_docker_client_cotainers_not_found):
     """
     Is the nbgrader directory created as part of setup?
     """

--- a/src/illumidesk/tests/illumidesk/setup_course/test_utils.py
+++ b/src/illumidesk/tests/illumidesk/setup_course/test_utils.py
@@ -15,12 +15,22 @@ def test_setup_utils_properties_after_initialization(setup_utils_environ):
 
 
 @pytest.mark.asyncio
-async def test_create_setup_utils_without_init_env_vars():
+async def test_create_setup_utils_without_illumidesk_dir_env_var():
     """
-    Do we get a type error when attempting to create a SetupUtils instance without the correct
-    initialization variables?
+    Do we get an environment error when attempting to create a SetupUtils instance without the illumidesk_dir
+    environment variable set to a proper value?
     """
-    with pytest.raises(TypeError):
+    with pytest.raises(EnvironmentError):
+        SetupUtils()
+
+
+@pytest.mark.asyncio
+async def test_create_setup_utils_without_illumidesk_dir_env_var(mock_docker_client_cotainers_not_found):
+    """
+    Do we get an environment error when attempting to create a SetupUtils instance without the illumidesk_dir
+    environment variable set to a proper value?
+    """
+    with pytest.raises(EnvironmentError):
         SetupUtils()
 
 
@@ -29,6 +39,4 @@ def test_initializer_setup_utils(setup_utils_environ):
     Does the initializer properly set the illumidesk directory property?
     """
     setup_utils = SetupUtils()
-    assert setup_utils.illumidesk_dir is not None
-    assert setup_utils.illumidesk_dir != ''
     assert setup_utils.illumidesk_dir == '/home/foo/illumidesk_deployment'

--- a/src/illumidesk/tests/illumidesk/setup_course/test_utils.py
+++ b/src/illumidesk/tests/illumidesk/setup_course/test_utils.py
@@ -1,0 +1,34 @@
+import pytest
+
+from illumidesk.setup_course.utils import SetupUtils
+
+
+def test_setup_utils_properties_after_initialization(setup_utils_environ):
+    """
+    Does the initializer properly set the illumidesk directory property?
+    """
+    setup_utils = SetupUtils()
+
+    assert setup_utils.docker_client is not None
+    assert setup_utils.jupyterhub_container_name == 'jupyterhub'
+    assert setup_utils.illumidesk_dir == '/home/foo/illumidesk_deployment'
+
+
+@pytest.mark.asyncio
+async def test_create_setup_utils_without_init_env_vars():
+    """
+    Do we get a type error when attempting to create a SetupUtils instance without the correct
+    initialization variables?
+    """
+    with pytest.raises(TypeError):
+        SetupUtils()
+
+
+def test_initializer_setup_utils(setup_utils_environ):
+    """
+    Does the initializer properly set the illumidesk directory property?
+    """
+    setup_utils = SetupUtils()
+    assert setup_utils.illumidesk_dir is not None
+    assert setup_utils.illumidesk_dir != ''
+    assert setup_utils.illumidesk_dir == '/home/foo/illumidesk_deployment'


### PR DESCRIPTION
- Handle missing `ILLUMIDESK_DIR` environment variable and set a default value
- Update `hosts.example` to replace the empty value with the default value
- Add basic tests

Closes #83 