### PR TITLE
Adds dependencies for plotly dash

### DIFF
--- a/ansible/roles/notebooks/files/requirements.txt
+++ b/ansible/roles/notebooks/files/requirements.txt
@@ -12,3 +12,5 @@ plotly-geo==1.0
 psycopg2-binary==2.8.5
 yellowbrick==1.1
 widgetsnbextension
+jupyter-dash==0.2.1.post1
+jupyter_server_proxy==1.5.0


### PR DESCRIPTION
Adds `jupyter-dash` and `jupyter-server-proxy` as notebooks dependencies. There are some issues related to accessing the dash when these packages are not installed previously.
