### PR TITLE
Adds lms_user_id in custom_fields

### DIFF
--- a/src/illumidesk/handlers/lti.py
+++ b/src/illumidesk/handlers/lti.py
@@ -82,7 +82,7 @@ class LTI13ConfigHandler(BaseHandler):
                                 'message_type': 'LtiResourceLinkRequest',
                                 'windowTarget': '_blank',
                                 'target_link_uri': target_link_url,
-                                'custom_fields': {'email': '$Person.email.primary'},
+                                'custom_fields': {'email': '$Person.email.primary', 'lms_user_id': '$User.id',},
                             },
                             {
                                 'placement': 'assignment_selection',

--- a/src/illumidesk/handlers/lti.py
+++ b/src/illumidesk/handlers/lti.py
@@ -103,7 +103,10 @@ class LTI13ConfigHandler(BaseHandler):
                 'use': 'sig',
             },
             'description': 'IllumiDesk Learning Tools Interoperability (LTI) v1.3 tool.',
-            'custom_fields': {'email': '$Person.email.primary'},
+            'custom_fields': {
+                'email': '$Person.email.primary',
+                'lms_user_id': '$User.id',
+            },
             'public_jwk_url': f'{target_link_url}hub/jwks',
             'target_link_uri': target_link_url,
             'oidc_initiation_url': f'{target_link_url}hub/oauth_login',

--- a/src/illumidesk/handlers/lti.py
+++ b/src/illumidesk/handlers/lti.py
@@ -103,10 +103,7 @@ class LTI13ConfigHandler(BaseHandler):
                 'use': 'sig',
             },
             'description': 'IllumiDesk Learning Tools Interoperability (LTI) v1.3 tool.',
-            'custom_fields': {
-                'email': '$Person.email.primary',
-                'lms_user_id': '$User.id',
-            },
+            'custom_fields': {'email': '$Person.email.primary', 'lms_user_id': '$User.id',},
             'public_jwk_url': f'{target_link_url}hub/jwks',
             'target_link_uri': target_link_url,
             'oidc_initiation_url': f'{target_link_url}hub/oauth_login',

--- a/src/tests/illumidesk/handlers/test_lti13_config_handler.py
+++ b/src/tests/illumidesk/handlers/test_lti13_config_handler.py
@@ -1,6 +1,7 @@
 from os import chmod
 from os import environ
 
+import json
 import pytest
 
 from tornado.web import RequestHandler
@@ -41,14 +42,102 @@ async def test_get_method_raises_permission_error_if_pem_file_is_protected(lti_c
 
 @pytest.mark.asyncio
 @patch('tornado.web.RequestHandler.write')
-async def test_get_method_reads_the_pem_file(mock_write, lti_config_environ):
+async def test_get_method_calls_write_method(mock_write, lti_config_environ):
     """
-    Is the private key written to the output buffer after after calling the handler's
-    get method?
+    Is the write method used in get method?
     """
     handler = mock_handler(RequestHandler)
     config_handler = LTI13ConfigHandler(handler.application, handler.request)
     # this method writes the output to internal buffer
     await config_handler.get()
-
     assert mock_write.called
+
+
+@pytest.mark.asyncio
+@patch('tornado.web.RequestHandler.write')
+async def test_get_calls_write_method_with_a_json(mock_write, lti_config_environ):
+    """
+    Does the write base method is invoked with a string?
+    """
+    handler = mock_handler(RequestHandler)
+    config_handler = LTI13ConfigHandler(handler.application, handler.request)
+    # this method writes the output to internal buffer
+    await config_handler.get()
+    # call_args is a list
+    write_args = mock_write.call_args[0]
+    # write_args == tuple
+    json_arg = write_args[0]    
+    assert type(json_arg) == str
+    assert json.loads(json_arg)
+
+
+@pytest.mark.asyncio
+@patch('tornado.web.RequestHandler.write')
+async def test_get_method_writes_a_json_with_required_keys(mock_write, lti_config_environ):
+    """
+    Does the get method write a json (jwks) with essential fields?
+    """
+    handler = mock_handler(RequestHandler)
+    config_handler = LTI13ConfigHandler(handler.application, handler.request)
+    # this method writes the output to internal buffer
+    await config_handler.get()
+    keys_at_0_level_expected = ['title', 'target_link_uri', 'scopes', 'public_jwk_url', 'public_jwk', 'oidc_initiation_url', 'extensions', 'custom_fields']
+    # call_args is a list
+    # so we're only extracting the json arg
+    json_arg = mock_write.call_args[0][0]
+    for required_key in keys_at_0_level_expected:
+        assert required_key in json_arg
+
+
+@pytest.mark.asyncio
+@patch('tornado.web.RequestHandler.write')
+async def test_get_method_writes_our_company_name_in_the_title_field(mock_write, lti_config_environ):
+    """
+    Does the get method write 'Illumidesk' value as the title in the json?
+    """
+    handler = mock_handler(RequestHandler)
+    config_handler = LTI13ConfigHandler(handler.application, handler.request)
+    # this method writes the output to internal buffer
+    await config_handler.get()    
+    # call_args is a list
+    # so we're only extracting the json arg
+    json_arg = mock_write.call_args[0][0]
+    title = json.loads(json_arg)['title']
+    assert title == 'IllumiDesk'
+
+
+@pytest.mark.asyncio
+@patch('tornado.web.RequestHandler.write')
+async def test_get_method_writes_email_field_within_custom_fields(mock_write, lti_config_environ):
+    """
+    Does the get method write 'email' field as a custom_fields?
+    """
+    handler = mock_handler(RequestHandler)
+    config_handler = LTI13ConfigHandler(handler.application, handler.request)
+    # this method writes the output to internal buffer
+    await config_handler.get()    
+    # call_args is a list
+    # so we're only extracting the json arg
+    json_arg = mock_write.call_args[0][0]
+    custom_fields = json.loads(json_arg)['custom_fields']
+    assert 'email' in custom_fields
+    assert '$Person.email.primary' == custom_fields['email']
+
+
+@pytest.mark.asyncio
+@patch('tornado.web.RequestHandler.write')
+async def test_get_method_writes_lms_user_id_field_within_custom_fields(mock_write, lti_config_environ):
+    """
+    Does the get method write 'lms_user_id' field within custom_fields and use the $User.id property?
+    """
+    handler = mock_handler(RequestHandler)
+    config_handler = LTI13ConfigHandler(handler.application, handler.request)
+    # this method writes the output to internal buffer
+    await config_handler.get()    
+    # call_args is a list
+    # so we're only extracting the json arg
+    json_arg = mock_write.call_args[0][0]
+    custom_fields = json.loads(json_arg)['custom_fields']
+    assert 'lms_user_id' in custom_fields
+    assert '$User.id' == custom_fields['lms_user_id']
+

--- a/src/tests/illumidesk/handlers/test_lti13_config_handler.py
+++ b/src/tests/illumidesk/handlers/test_lti13_config_handler.py
@@ -66,7 +66,7 @@ async def test_get_calls_write_method_with_a_json(mock_write, lti_config_environ
     # call_args is a list
     write_args = mock_write.call_args[0]
     # write_args == tuple
-    json_arg = write_args[0]    
+    json_arg = write_args[0]
     assert type(json_arg) == str
     assert json.loads(json_arg)
 
@@ -81,7 +81,16 @@ async def test_get_method_writes_a_json_with_required_keys(mock_write, lti_confi
     config_handler = LTI13ConfigHandler(handler.application, handler.request)
     # this method writes the output to internal buffer
     await config_handler.get()
-    keys_at_0_level_expected = ['title', 'target_link_uri', 'scopes', 'public_jwk_url', 'public_jwk', 'oidc_initiation_url', 'extensions', 'custom_fields']
+    keys_at_0_level_expected = [
+        'title',
+        'target_link_uri',
+        'scopes',
+        'public_jwk_url',
+        'public_jwk',
+        'oidc_initiation_url',
+        'extensions',
+        'custom_fields',
+    ]
     # call_args is a list
     # so we're only extracting the json arg
     json_arg = mock_write.call_args[0][0]
@@ -98,7 +107,7 @@ async def test_get_method_writes_our_company_name_in_the_title_field(mock_write,
     handler = mock_handler(RequestHandler)
     config_handler = LTI13ConfigHandler(handler.application, handler.request)
     # this method writes the output to internal buffer
-    await config_handler.get()    
+    await config_handler.get()
     # call_args is a list
     # so we're only extracting the json arg
     json_arg = mock_write.call_args[0][0]
@@ -115,7 +124,7 @@ async def test_get_method_writes_email_field_within_custom_fields(mock_write, lt
     handler = mock_handler(RequestHandler)
     config_handler = LTI13ConfigHandler(handler.application, handler.request)
     # this method writes the output to internal buffer
-    await config_handler.get()    
+    await config_handler.get()
     # call_args is a list
     # so we're only extracting the json arg
     json_arg = mock_write.call_args[0][0]
@@ -133,11 +142,10 @@ async def test_get_method_writes_lms_user_id_field_within_custom_fields(mock_wri
     handler = mock_handler(RequestHandler)
     config_handler = LTI13ConfigHandler(handler.application, handler.request)
     # this method writes the output to internal buffer
-    await config_handler.get()    
+    await config_handler.get()
     # call_args is a list
     # so we're only extracting the json arg
     json_arg = mock_write.call_args[0][0]
     custom_fields = json.loads(json_arg)['custom_fields']
     assert 'lms_user_id' in custom_fields
     assert '$User.id' == custom_fields['lms_user_id']
-


### PR DESCRIPTION
Modifies the LTI13ConfigHandler to add 'lms_user_id' field in *custom_fields* section: at top level and within course_navigation placement setting.
This adds some unit tests to protect this change.
Closes #117