### PR TITLE
Update conditional in lti11 authenticator with Student string

### DIFF
--- a/src/illumidesk/authenticators/authenticator.py
+++ b/src/illumidesk/authenticators/authenticator.py
@@ -232,7 +232,7 @@ class LTI11Authenticator(LTIAuthenticator):
             # the Learner role
             lis_outcome_service_url = None
             lis_result_sourcedid = None
-            if user_role == 'Learner':
+            if user_role == 'Learner' or user_role == 'Student':
                 # the next fields must come in args
                 if 'lis_outcome_service_url' in args and args['lis_outcome_service_url'] is not None:
                     lis_outcome_service_url = args['lis_outcome_service_url']

--- a/src/tests/illumidesk/authenticators/test_lti11_authenticator.py
+++ b/src/tests/illumidesk/authenticators/test_lti11_authenticator.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from illumidesk.authenticators.validator import LTI11LaunchValidator
 from illumidesk.authenticators.authenticator import LTI11Authenticator
+from illumidesk.handlers.lms_grades import LTIGradesSenderControlFile
 from tests.illumidesk.factory import factory_lti11_complete_launch_args
 
 
@@ -78,6 +79,96 @@ async def test_authenticator_uses_lti11validator():
 
         _ = await authenticator.authenticate(handler, None)
         assert mock_validator.called
+
+
+@pytest.mark.asyncio
+async def test_authenticator_uses_lti_grades_sender_control_file_when_student(tmp_path):
+    """
+    Is the LTIGradesSenderControlFile class register_data method called when setting the user_role with the
+    Student string?
+    """
+
+    def _change_flag():
+        LTIGradesSenderControlFile.FILE_LOADED = True
+
+    with patch.object(LTI11LaunchValidator, 'validate_launch_request', return_value=True):
+        with patch.object(LTIGradesSenderControlFile, 'register_data', return_value=None) as mock_register_data:
+            with patch.object(
+                LTIGradesSenderControlFile, '_loadFromFile', return_value=None
+            ) as mock_loadFromFileMethod:
+                mock_loadFromFileMethod.side_effect = _change_flag
+                sender_controlfile = LTIGradesSenderControlFile(tmp_path)
+                authenticator = LTI11Authenticator()
+                handler = Mock(spec=RequestHandler)
+                request = HTTPServerRequest(method='POST', connection=Mock(),)
+                handler.request = request
+                handler.request.arguments = factory_lti11_complete_launch_args(lms_vendor='edx', role='Student')
+                handler.request.get_argument = lambda x, strip=True: factory_lti11_complete_launch_args('Student')[x][
+                    0
+                ].decode()
+
+                _ = await authenticator.authenticate(handler, None)
+                assert mock_register_data.called
+
+
+@pytest.mark.asyncio
+async def test_authenticator_uses_lti_grades_sender_control_file_when_learner(tmp_path):
+    """
+    Is the LTIGradesSenderControlFile class register_data method called when setting the user_role with the
+    Learner string?
+    """
+
+    def _change_flag():
+        LTIGradesSenderControlFile.FILE_LOADED = True
+
+    with patch.object(LTI11LaunchValidator, 'validate_launch_request', return_value=True):
+        with patch.object(LTIGradesSenderControlFile, 'register_data', return_value=None) as mock_register_data:
+            with patch.object(
+                LTIGradesSenderControlFile, '_loadFromFile', return_value=None
+            ) as mock_loadFromFileMethod:
+                mock_loadFromFileMethod.side_effect = _change_flag
+                sender_controlfile = LTIGradesSenderControlFile(tmp_path)
+                authenticator = LTI11Authenticator()
+                handler = Mock(spec=RequestHandler)
+                request = HTTPServerRequest(method='POST', connection=Mock(),)
+                handler.request = request
+                handler.request.arguments = factory_lti11_complete_launch_args(lms_vendor='canvas', role='Learner')
+                handler.request.get_argument = lambda x, strip=True: factory_lti11_complete_launch_args('Learner')[x][
+                    0
+                ].decode()
+
+                _ = await authenticator.authenticate(handler, None)
+                assert mock_register_data.called
+
+
+@pytest.mark.asyncio
+async def test_authenticator_does_not_set_lti_grades_sender_control_file_when_instructor(tmp_path):
+    """
+    Is the LTIGradesSenderControlFile class register_data method called when setting the user_role with the
+    Instructor string?
+    """
+
+    def _change_flag():
+        LTIGradesSenderControlFile.FILE_LOADED = True
+
+    with patch.object(LTI11LaunchValidator, 'validate_launch_request', return_value=True):
+        with patch.object(LTIGradesSenderControlFile, 'register_data', return_value=None) as mock_register_data:
+            with patch.object(
+                LTIGradesSenderControlFile, '_loadFromFile', return_value=None
+            ) as mock_loadFromFileMethod:
+                mock_loadFromFileMethod.side_effect = _change_flag
+                sender_controlfile = LTIGradesSenderControlFile(tmp_path)
+                authenticator = LTI11Authenticator()
+                handler = Mock(spec=RequestHandler)
+                request = HTTPServerRequest(method='POST', connection=Mock(),)
+                handler.request = request
+                handler.request.arguments = factory_lti11_complete_launch_args(lms_vendor='canvas', role='Instructor')
+                handler.request.get_argument = lambda x, strip=True: factory_lti11_complete_launch_args('Instructor')[
+                    x
+                ][0].decode()
+
+                _ = await authenticator.authenticate(handler, None)
+                assert not mock_register_data.called
 
 
 @pytest.mark.asyncio

--- a/src/tests/illumidesk/factory.py
+++ b/src/tests/illumidesk/factory.py
@@ -121,7 +121,7 @@ def factory_lti11_complete_launch_args(lms_vendor: str, role: str = 'Instructor'
         'oauth_callback': ['about:blank'.encode()],
         'resource_link_id': ['888efe72d4bbbdf90619353bb8ab5965ccbe9b3f'.encode()],
         'resource_link_title': ['IllumiDesk'.encode()],
-        'roles': ['Instructor'.encode() if role == 'Instructor' else role.encode()],
+        'roles': [role.encode()],
         'tool_consumer_info_product_family_code': [lms_vendor.encode()],
         'tool_consumer_info_version': ['cloud'.encode()],
         'tool_consumer_instance_contact_email': ['notifications@mylms.com'.encode()],


### PR DESCRIPTION
Add conditional to LTI 1.1 authenticator to consider the `Student` string when setting the `user_role` key within the `auth_state` dictionary.

Closes #131 