### PR TITLE
Switch default branch from master to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--   Thank you for your contribution. Before you submit the pull request:
-1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/IllumiDesk/illumidesk/blob/master/CONTRIBUTING.md
+1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/IllumiDesk/illumidesk/blob/main/CONTRIBUTING.md
 2. Test your changes and attach their results to the pull request.
 3. Update the relevant documentation.
 -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
 branches:
   only:
-    - master
+    - main
     - production
 notifications:
   email: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ This project uses Python and Javascript (for the most part). We use the followin
 
 Linters and formatters are set up with pre-commit-hooks. If you aren't used to pre-commit hooks you may gasp for oxygen once you attempt to commit your changes for the first time. Even when you do get used to it the idea of having to run the same add/commit multiple times may be nerve racking. (Ok so there is a little drama in there, its not that bad). Having the pre-commit-hooks in place helps speed up the PR review process so we can focus on the important stuff.
 
-The CI/CD pipeline will check coding style but will not error out. There may be situations where minor coding style errors are less important that in important merges to the master trunk. However, these are considered on a case-by-case basis.
+The CI/CD pipeline will check coding style but will not error out. There may be situations where minor coding style errors are less important that in important merges to the `main` branch. However, these are considered on a case-by-case basis.
 
 ## Commit Messages, Changelog, and Releases
 
@@ -76,11 +76,11 @@ This project uses Semantic Versioning with Conventional Commits to track major, 
 
 Once a new version is released, assets should be published with the new tag, such as docker images, pip/npm packages, and GitHub repo release tags.
 
-For the most part, contributors do not need to worry about commit message formats, since all commits from a Pull Request are squashed and merged before merging to master. Commit messages are updated to the standard format during this step.
+For the most part, contributors do not need to worry about commit message formats, since all commits from a Pull Request are squashed and merged before merging to `main`. Commit messages are updated to the standard format during this step.
 
 ### For Maintainers
 
-When squashing and merging to the `master` branch, use the following format to provide consistent updates to the `CHANGELOG.md` file:
+When squashing and merging to the `main` branch, use the following format to provide consistent updates to the `CHANGELOG.md` file:
 
     <Commit Type>(scope): <Merge Description>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.com/IllumiDesk/illumidesk.svg?branch=master)](https://travis-ci.com/IllumiDesk/illumidesk)
-[![codecov](https://codecov.io/gh/IllumiDesk/illumidesk/branch/master/graph/badge.svg)](https://codecov.io/gh/IllumiDesk/illumidesk)
+[![Build Status](https://travis-ci.com/IllumiDesk/illumidesk.svg?branch=main)](https://travis-ci.com/IllumiDesk/illumidesk)
+[![codecov](https://codecov.io/gh/IllumiDesk/illumidesk/branch/main/graph/badge.svg)](https://codecov.io/gh/IllumiDesk/illumidesk)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![Code style black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,7 @@ IllumiDesk automates security scanning and dependency upgrades throughout the so
 
 - Scan docker images after building and pushing the images to the registry.
 
-- Block merges to the master branch which do not pass all tests and/or do not have the sign off from one of the project's maintainers.
+- Block merges to the `main` branch which do not pass all tests and/or do not have the sign off from one of the project's maintainers.
 
 - Ensure that all dependencies used for deployments are set to specific releases.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
         target: 100%
         paths: "src/tests/"
         branches: 
-          - master
+          - main
         if_not_found: success
         if_ci_failed: error
         informational: false
@@ -18,7 +18,7 @@ coverage:
         paths: 
           - "!src/tests/"
         branches: 
-          - master
+          - main
         if_not_found: success
         if_ci_failed: error
         informational: false


### PR DESCRIPTION
Updates docs to replace `master` branch references to `main` branch references.