### PR TITLE
Install nfs-common required by setups with NFS

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -30,6 +30,16 @@
     'virtualenv'
   ]
 
+- name: install system dependencies required by efs
+  apt:
+    name:  "{{ item }}"
+    state: latest
+    update_cache: yes
+  loop: [
+    'nfs-common',
+  ]
+  when: aws_efs_enabled|bool
+
 - name: install docker-compose
   get_url:
     url: https://github.com/docker/compose/releases/download/1.25.5/docker-compose-Linux-x86_64


### PR DESCRIPTION
Install the `nfs-common` package when the playbook is flagged to enable AWS EFS, since it's not always included with Ubuntu distros.

#158 