### PR TITLE
Refactoring to simplify the logic in spawner classes

### DIFF
--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
@@ -87,8 +87,8 @@ c.JupyterHub.db_url = 'postgresql://{user}:{password}@{host}/{db}'.format(
 c.JupyterHub.authenticator_class = LTI11Authenticator
 
 # Spawn containers with by role or workspace type
-# c.JupyterHub.spawner_class = IllumiDeskRoleDockerSpawner
-c.JupyterHub.spawner_class = IllumiDeskWorkSpaceDockerSpawner
+c.JupyterHub.spawner_class = IllumiDeskRoleDockerSpawner
+# c.JupyterHub.spawner_class = IllumiDeskWorkSpaceDockerSpawner
 
 ##########################################
 # END JUPYTERHUB APPLICATION

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
@@ -87,8 +87,8 @@ c.JupyterHub.db_url = 'postgresql://{user}:{password}@{host}/{db}'.format(
 c.JupyterHub.authenticator_class = LTI11Authenticator
 
 # Spawn containers with by role or workspace type
-c.JupyterHub.spawner_class = IllumiDeskRoleDockerSpawner
-# c.JupyterHub.spawner_class = IllumiDeskWorkSpaceDockerSpawner
+# c.JupyterHub.spawner_class = IllumiDeskRoleDockerSpawner
+c.JupyterHub.spawner_class = IllumiDeskWorkSpaceDockerSpawner
 
 ##########################################
 # END JUPYTERHUB APPLICATION

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
@@ -9,7 +9,7 @@ from illumidesk.authenticators.authenticator import LTI11Authenticator
 from illumidesk.authenticators.authenticator import setup_course_hook
 from illumidesk.grades.handlers import SendGradesHandler
 from illumidesk.spawners.spawners import IllumiDeskRoleDockerSpawner
-from illumidesk.spawners.spawner import IllumiDeskWorkSpaceDockerSpawner  # noqa: F401
+from illumidesk.spawners.spawners import IllumiDeskWorkSpaceDockerSpawner  # noqa: F401
 
 
 c = get_config()

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti13.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti13.py
@@ -8,13 +8,10 @@ from dockerspawner import DockerSpawner  # noqa: F401
 from illumidesk.authenticators.authenticator import LTI13Authenticator
 from illumidesk.authenticators.authenticator import setup_course_hook
 from illumidesk.grades.handlers import SendGradesHandler
-from illumidesk.handlers.lms_grades import SendGradesHandler
-from illumidesk.handlers.lti import LTI13ConfigHandler
-from illumidesk.handlers.lti import LTI13JWKSHandler
 from illumidesk.lti13.handlers import LTI13ConfigHandler
 from illumidesk.lti13.handlers import LTI13JWKSHandler
 from illumidesk.spawners.spawners import IllumiDeskRoleDockerSpawner
-from illumidesk.spawners.spawner import IllumiDeskWorkSpaceDockerSpawner  # noqa: F401
+from illumidesk.spawners.spawners import IllumiDeskWorkSpaceDockerSpawner  # noqa: F401
 
 
 c = get_config()

--- a/src/illumidesk/spawners/hooks.py
+++ b/src/illumidesk/spawners/hooks.py
@@ -9,7 +9,7 @@ def custom_auth_state_hook(spawner: Spawner, auth_state: dict) -> None:
     The USER_ROLE environment variable is used to select the notebook image based
     on the user's role.
     """
-    if not auth_state:        
+    if not auth_state:
         raise ValueError('auth_state not enabled.')
     spawner.log.debug('auth_state_hook set with %s role' % auth_state['user_role'])
     spawner.environment['USER_ROLE'] = auth_state['user_role']
@@ -19,8 +19,7 @@ def custom_auth_state_hook(spawner: Spawner, auth_state: dict) -> None:
         spawner.log.debug('Assigned USER_WORKSPACE_TYPE env var to %s' % spawner.environment['USER_WORKSPACE_TYPE'])
 
 
-
-def custom_pre_spawn_hook(spawner: Spawner) -> None:    
+def custom_pre_spawn_hook(spawner: Spawner) -> None:
     """
     Creates the user directory based on information passed from the
     `spawner` object.

--- a/src/illumidesk/spawners/hooks.py
+++ b/src/illumidesk/spawners/hooks.py
@@ -1,9 +1,11 @@
 import os
 import shutil
-from dockerspawner import DockerSpawner
+from jupyterhub.spawner import Spawner
+
+from illumidesk import spawners
 
 
-async def custom_auth_state_hook(spawner: DockerSpawner, auth_state: dict) -> None:
+def custom_auth_state_hook(spawner: Spawner, auth_state: dict) -> None:
     """
     Customized hook to assign USER_ROLE environment variable to LTI user role.
     The USER_ROLE environment variable is used to select the notebook image based
@@ -20,7 +22,7 @@ async def custom_auth_state_hook(spawner: DockerSpawner, auth_state: dict) -> No
 
 
 
-def custom_pre_spawn_hook(spawner: DockerSpawner) -> None:    
+def custom_pre_spawn_hook(spawner: Spawner) -> None:    
     """
     Creates the user directory based on information passed from the
     `spawner` object.
@@ -32,6 +34,7 @@ def custom_pre_spawn_hook(spawner: DockerSpawner) -> None:
     username = spawner.user.name
     user_path = os.path.join('/home', username)
     if not os.path.exists(user_path):
+        spawner.log.debug(f'Creating workdir {user_path} for the user {username}')
         os.mkdir(user_path)
         shutil.chown(
             user_path, user=int(os.environ.get('MNT_HOME_DIR_UID')), group=int(os.environ.get('MNT_HOME_DIR_GID')),

--- a/src/illumidesk/spawners/hooks.py
+++ b/src/illumidesk/spawners/hooks.py
@@ -2,8 +2,6 @@ import os
 import shutil
 from jupyterhub.spawner import Spawner
 
-from illumidesk import spawners
-
 
 def custom_auth_state_hook(spawner: Spawner, auth_state: dict) -> None:
     """

--- a/src/illumidesk/spawners/hooks.py
+++ b/src/illumidesk/spawners/hooks.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+from dockerspawner import DockerSpawner
+
+
+async def custom_auth_state_hook(spawner: DockerSpawner, auth_state: dict) -> None:
+    """
+    Customized hook to assign USER_ROLE environment variable to LTI user role.
+    The USER_ROLE environment variable is used to select the notebook image based
+    on the user's role.
+    """
+    if not auth_state:        
+        raise ValueError('auth_state not enabled.')
+    spawner.log.debug('auth_state_hook set with %s role' % auth_state['user_role'])
+    spawner.environment['USER_ROLE'] = auth_state['user_role']
+    spawner.log.debug('Assigned USER_ROLE env var to %s' % spawner.environment['USER_ROLE'])
+    if 'workspace_type' in auth_state:
+        spawner.environment['USER_WORKSPACE_TYPE'] = auth_state['workspace_type']
+        spawner.log.debug('Assigned USER_WORKSPACE_TYPE env var to %s' % spawner.environment['USER_WORKSPACE_TYPE'])
+
+
+
+def custom_pre_spawn_hook(spawner: DockerSpawner) -> None:    
+    """
+    Creates the user directory based on information passed from the
+    `spawner` object.
+    Args:
+        spawner: JupyterHub spawner object
+    """
+    if not spawner.user.name:
+        raise ValueError('Spawner object does not contain the username')
+    username = spawner.user.name
+    user_path = os.path.join('/home', username)
+    if not os.path.exists(user_path):
+        os.mkdir(user_path)
+        shutil.chown(
+            user_path, user=int(os.environ.get('MNT_HOME_DIR_UID')), group=int(os.environ.get('MNT_HOME_DIR_GID')),
+        )
+        os.chmod(user_path, 0o755)

--- a/src/illumidesk/spawners/hooks.py
+++ b/src/illumidesk/spawners/hooks.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+
 from jupyterhub.spawner import Spawner
 
 

--- a/src/illumidesk/spawners/spawners.py
+++ b/src/illumidesk/spawners/spawners.py
@@ -9,13 +9,16 @@ class IllumiDeskDockerSpawner(DockerSpawner):
     """
     Defines the common behavior for our Spwaners that work with LTI versions 1.1 and 1.3
     """
+
     def _get_image_name(self) -> str:
-        raise NotImplementedError('It is necessary to implement the logic to indicate how to get the image name based on auth_state or environ in this child class')
+        raise NotImplementedError(
+            'It is necessary to implement the logic to indicate how to get the image name based on auth_state or environ in this child class'
+        )
 
     def auth_state_hook(self, spawner: DockerSpawner, auth_state: dict) -> None:
         # call our custom hook from here without issue related with 'invalid arguments number given'
         custom_auth_state_hook(spawner, auth_state)
-    
+
     def pre_spawn_hook(self, spawner) -> None:
         custom_pre_spawn_hook(spawner)
 
@@ -63,6 +66,7 @@ class IllumiDeskWorkSpaceDockerSpawner(IllumiDeskDockerSpawner):
     1. That the `Authenticator.enable_auth_state = True`
     2. That the user's `WORKSPACE_TYPE` environment variable is set
     """
+
     def _get_image_name(self) -> str:
         """
         Given a user role saved in spawner.environ, return the right image
@@ -72,7 +76,7 @@ class IllumiDeskWorkSpaceDockerSpawner(IllumiDeskDockerSpawner):
         """
         workspace_type = self.environment.get('USER_WORKSPACE_TYPE') or 'notebook'
         self.log.debug('User %s has workspace type: %s' % (self.user.name, workspace_type))
-        
+
         # default to standard image, otherwise assign image based on role
         self.log.debug('User role used to set image: %s' % workspace_type)
         docker_image = str(os.environ.get('DOCKER_STANDARD_IMAGE'))

--- a/src/illumidesk/spawners/spawners.py
+++ b/src/illumidesk/spawners/spawners.py
@@ -1,13 +1,14 @@
 import os
 
 from dockerspawner import DockerSpawner
+
 from illumidesk.spawners.hooks import custom_auth_state_hook
 from illumidesk.spawners.hooks import custom_pre_spawn_hook
 
 
-class IllumiDeskDockerSpawner(DockerSpawner):
+class IllumiDeskBaseDockerSpawner(DockerSpawner):
     """
-    Defines the common behavior for our Spwaners that work with LTI versions 1.1 and 1.3
+    Extends the DockerSpawner by defining the common behavior for our Spwaners that work with LTI versions 1.1 and 1.3
     """
 
     def _get_image_name(self) -> str:
@@ -28,7 +29,7 @@ class IllumiDeskDockerSpawner(DockerSpawner):
         return super().start()
 
 
-class IllumiDeskRoleDockerSpawner(IllumiDeskDockerSpawner):
+class IllumiDeskRoleDockerSpawner(IllumiDeskBaseDockerSpawner):
     """
     Custom DockerSpawner which assigns a user notebook image
     based on the user's role. This spawner requires:
@@ -58,7 +59,7 @@ class IllumiDeskRoleDockerSpawner(IllumiDeskDockerSpawner):
         return docker_image
 
 
-class IllumiDeskWorkSpaceDockerSpawner(IllumiDeskDockerSpawner):
+class IllumiDeskWorkSpaceDockerSpawner(IllumiDeskBaseDockerSpawner):
     """
     Custom DockerSpawner which assigns a user notebook image
     based on the user's workspace type. This spawner requires:

--- a/src/illumidesk/spawners/spawners.py
+++ b/src/illumidesk/spawners/spawners.py
@@ -12,14 +12,14 @@ class IllumiDeskDockerSpawner(DockerSpawner):
     def _get_image_name(self) -> str:
         raise NotImplementedError('It is necessary to implement the logic to indicate how to get the image name based on auth_state or environ in this child class')
 
-    def auth_state_hook(self, spawner: DockerSpawner, auth_state: dict)-> None:
+    def auth_state_hook(self, spawner: DockerSpawner, auth_state: dict) -> None:
         # call our custom hook from here without issue related with 'invalid arguments number given'
         custom_auth_state_hook(spawner, auth_state)
     
     def pre_spawn_hook(self, spawner) -> None:
         custom_pre_spawn_hook(spawner)
 
-    def start(self) -> None:        
+    def start(self) -> None:
         self.image = self._get_image_name()
         self.log.debug('Starting with image: %s' % self.image)
         return super().start()
@@ -35,7 +35,7 @@ class IllumiDeskRoleDockerSpawner(IllumiDeskDockerSpawner):
 
     def _get_image_name(self) -> str:
         """
-        Given a user role in the environ, return the right image        
+        Given a user role in the environ, return the right image
         Returns:
             docker_image: docker image used to spawn container based on role
         """

--- a/src/illumidesk/spawners/spawners.py
+++ b/src/illumidesk/spawners/spawners.py
@@ -12,6 +12,13 @@ class IllumiDeskDockerSpawner(DockerSpawner):
     def _get_image_name(self) -> str:
         raise NotImplementedError('It is necessary to implement the logic to indicate how to get the image name based on auth_state or environ in this child class')
 
+    def auth_state_hook(self, spawner: DockerSpawner, auth_state: dict)-> None:
+        # call our custom hook from here without issue related with 'invalid arguments number given'
+        custom_auth_state_hook(spawner, auth_state)
+    
+    def pre_spawn_hook(self, spawner) -> None:
+        custom_pre_spawn_hook(spawner)
+
     def start(self) -> None:        
         self.image = self._get_image_name()
         self.log.debug('Starting with image: %s' % self.image)
@@ -77,8 +84,3 @@ class IllumiDeskWorkSpaceDockerSpawner(IllumiDeskDockerSpawner):
             docker_image = str(os.environ.get('DOCKER_VSCODE_IMAGE'))
         self.log.debug('Image based on workspace type set to %s' % docker_image)
         return docker_image
-
-
-# set the hooks
-IllumiDeskDockerSpawner.pre_spawn_hook = custom_pre_spawn_hook
-IllumiDeskDockerSpawner.auth_state_hook = custom_auth_state_hook

--- a/src/tests/illumidesk/conftest.py
+++ b/src/tests/illumidesk/conftest.py
@@ -1,3 +1,4 @@
+from os import environ
 import pytest
 import uuid
 
@@ -185,13 +186,37 @@ def lti13_login_params_dict(lti13_login_params):
 
 
 @pytest.fixture
-def mock_user():
-    mock_user = Mock()
-    attrs = {
-        'environment.get.side_effect': None,
-    }
-    mock_user.configure_mock(**attrs)
-    return mock_user
+def mock_jhub_user(request):
+    """
+    Creates a Authenticated User mock by returning a wrapper function to help us to customize its creation
+    Usage:
+        user_mocked = mock_jhub_user(environ={'USER_ROLE': 'Instructor'})
+        or
+        user_mocked = mock_jhub_user()
+        or
+        user_mocked = mock_jhub_user(environ={'USER_ROLE': 'Instructor'}, auth_state=[])
+    """
+    def _get_with_params(environ: dict = None, auth_state: list=[]) -> Mock:
+        """
+        wrapper function that accept environment and auth_state
+        Args:
+            auth_state: Helps with the `the get_auth_state` method
+        """
+        mock_user = Mock()
+        mock_spawner = Mock()
+        # define the mock attrs
+        spawner_attrs = {
+            'environment': environ or {}
+        }
+        mock_spawner.configure_mock(**spawner_attrs)
+        attrs = {
+            'name': 'user1', 
+            'spawner': mock_spawner,
+            "get_auth_state.side_effect": auth_state or [],
+        }
+        mock_user.configure_mock(**attrs)
+        return mock_user
+    return _get_with_params
 
 
 @pytest.fixture

--- a/src/tests/illumidesk/conftest.py
+++ b/src/tests/illumidesk/conftest.py
@@ -195,6 +195,7 @@ def mock_jhub_user(request):
         or
         user_mocked = mock_jhub_user(environ={'USER_ROLE': 'Instructor'}, auth_state=[])
     """
+
     def _get_with_params(environ: dict = None, auth_state: list = []) -> Mock:
         """
         wrapper function that accept environment and auth_state
@@ -204,9 +205,7 @@ def mock_jhub_user(request):
         mock_user = Mock()
         mock_spawner = Mock()
         # define the mock attrs
-        spawner_attrs = {
-            'environment': environ or {}
-        }
+        spawner_attrs = {'environment': environ or {}}
         mock_spawner.configure_mock(**spawner_attrs)
         attrs = {
             'name': 'user1',
@@ -215,6 +214,7 @@ def mock_jhub_user(request):
         }
         mock_user.configure_mock(**attrs)
         return mock_user
+
     return _get_with_params
 
 

--- a/src/tests/illumidesk/conftest.py
+++ b/src/tests/illumidesk/conftest.py
@@ -1,4 +1,3 @@
-from os import environ
 import pytest
 import uuid
 
@@ -196,7 +195,7 @@ def mock_jhub_user(request):
         or
         user_mocked = mock_jhub_user(environ={'USER_ROLE': 'Instructor'}, auth_state=[])
     """
-    def _get_with_params(environ: dict = None, auth_state: list=[]) -> Mock:
+    def _get_with_params(environ: dict = None, auth_state: list = []) -> Mock:
         """
         wrapper function that accept environment and auth_state
         Args:
@@ -210,7 +209,7 @@ def mock_jhub_user(request):
         }
         mock_spawner.configure_mock(**spawner_attrs)
         attrs = {
-            'name': 'user1', 
+            'name': 'user1',
             'spawner': mock_spawner,
             "get_auth_state.side_effect": auth_state or [],
         }

--- a/src/tests/illumidesk/spawners/test_hooks.py
+++ b/src/tests/illumidesk/spawners/test_hooks.py
@@ -9,7 +9,7 @@ async def test_ensure_environment_assigned_to_user_role_from_auth_state_in_spawn
     Does the user's docker container environment reflect his/her role?
     """
     sut = IllumiDeskRoleDockerSpawner()
-    await custom_auth_state_hook(sut, auth_state_dict['auth_state'])
+    custom_auth_state_hook(sut, auth_state_dict['auth_state'])
     # make sure the hook set the environment variables
     assert sut.environment['USER_ROLE'] == 'Learner'
 
@@ -20,7 +20,7 @@ async def test_ensure_environment_assigned_to_workspace_type_from_auth_state_in_
     Does the user's docker container environment reflect his/her role?
     """
     sut = IllumiDeskRoleDockerSpawner()
-    await custom_auth_state_hook(sut, auth_state_dict['auth_state'])
+    custom_auth_state_hook(sut, auth_state_dict['auth_state'])
     # make sure the hook set the environment variables
     assert sut.environment['USER_WORKSPACE_TYPE'] == 'notebook'
 
@@ -33,7 +33,7 @@ async def test_auth_state_hook_does_not_raise_an_error_if_workspace_type_is_miss
     sut = IllumiDeskRoleDockerSpawner()
     # remove the workspace_type key from auth_state
     del auth_state_dict['auth_state']['workspace_type']
-    await custom_auth_state_hook(sut, auth_state_dict['auth_state'])
+    custom_auth_state_hook(sut, auth_state_dict['auth_state'])
     # make sure the hook set the environment
     assert sut.environment
     assert 'USER_WORKSPACE_TYPE' not in sut.environment

--- a/src/tests/illumidesk/spawners/test_hooks.py
+++ b/src/tests/illumidesk/spawners/test_hooks.py
@@ -1,0 +1,39 @@
+import pytest
+from illumidesk.spawners.hooks import custom_auth_state_hook
+from illumidesk.spawners.spawners import IllumiDeskRoleDockerSpawner
+
+@pytest.mark.asyncio
+async def test_ensure_environment_assigned_to_user_role_from_auth_state_in_spawner_environment(auth_state_dict
+):
+    """
+    Does the user's docker container environment reflect his/her role?
+    """
+    sut = IllumiDeskRoleDockerSpawner()
+    await custom_auth_state_hook(sut, auth_state_dict['auth_state'])
+    # make sure the hook set the environment variables
+    assert sut.environment['USER_ROLE'] == 'Learner'
+
+@pytest.mark.asyncio
+async def test_ensure_environment_assigned_to_workspace_type_from_auth_state_in_spawner_environment(auth_state_dict
+):
+    """
+    Does the user's docker container environment reflect his/her role?
+    """
+    sut = IllumiDeskRoleDockerSpawner()
+    await custom_auth_state_hook(sut, auth_state_dict['auth_state'])
+    # make sure the hook set the environment variables
+    assert sut.environment['USER_WORKSPACE_TYPE'] == 'notebook'
+
+@pytest.mark.asyncio
+async def test_auth_state_hook_does_not_raise_an_error_if_workspace_type_is_missing(auth_state_dict
+):
+    """
+    Does the user's docker container environment reflect his/her role?
+    """
+    sut = IllumiDeskRoleDockerSpawner()
+    # remove the workspace_type key from auth_state
+    del auth_state_dict['auth_state']['workspace_type']
+    await custom_auth_state_hook(sut, auth_state_dict['auth_state'])
+    # make sure the hook set the environment
+    assert sut.environment
+    assert 'USER_WORKSPACE_TYPE' not in sut.environment

--- a/src/tests/illumidesk/spawners/test_hooks.py
+++ b/src/tests/illumidesk/spawners/test_hooks.py
@@ -2,9 +2,9 @@ import pytest
 from illumidesk.spawners.hooks import custom_auth_state_hook
 from illumidesk.spawners.spawners import IllumiDeskRoleDockerSpawner
 
+
 @pytest.mark.asyncio
-async def test_ensure_environment_assigned_to_user_role_from_auth_state_in_spawner_environment(auth_state_dict
-):
+async def test_ensure_environment_assigned_to_user_role_from_auth_state_in_spawner_environment(auth_state_dict):
     """
     Does the user's docker container environment reflect his/her role?
     """
@@ -13,9 +13,9 @@ async def test_ensure_environment_assigned_to_user_role_from_auth_state_in_spawn
     # make sure the hook set the environment variables
     assert sut.environment['USER_ROLE'] == 'Learner'
 
+
 @pytest.mark.asyncio
-async def test_ensure_environment_assigned_to_workspace_type_from_auth_state_in_spawner_environment(auth_state_dict
-):
+async def test_ensure_environment_assigned_to_workspace_type_from_auth_state_in_spawner_environment(auth_state_dict):
     """
     Does the user's docker container environment reflect his/her role?
     """
@@ -24,9 +24,9 @@ async def test_ensure_environment_assigned_to_workspace_type_from_auth_state_in_
     # make sure the hook set the environment variables
     assert sut.environment['USER_WORKSPACE_TYPE'] == 'notebook'
 
+
 @pytest.mark.asyncio
-async def test_auth_state_hook_does_not_raise_an_error_if_workspace_type_is_missing(auth_state_dict
-):
+async def test_auth_state_hook_does_not_raise_an_error_if_workspace_type_is_missing(auth_state_dict):
     """
     Does the user's docker container environment reflect his/her role?
     """

--- a/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
+++ b/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
@@ -1,5 +1,4 @@
 import os
-from os import environ
 import pytest
 import types
 
@@ -19,11 +18,10 @@ def test_get_image_name_returns_correct_image_for_student_role(
     sut.environment['USER_ROLE'] = 'Student'
     sut.user = mock_jhub_user()
 
-    assert sut._get_image_name() == os.environ.get('DOCKER_LEARNER_IMAGE')    
+    assert sut._get_image_name() == os.environ.get('DOCKER_LEARNER_IMAGE')
 
 
-def test_get_image_name_returns_correct_image_for_learner_role(setup_image_environ, mock_jhub_user
-):
+def test_get_image_name_returns_correct_image_for_learner_role(setup_image_environ, mock_jhub_user):
     """
     Does the internal get_image_name method return student image when using the learner role?
     """
@@ -34,8 +32,7 @@ def test_get_image_name_returns_correct_image_for_learner_role(setup_image_envir
     assert sut._get_image_name() == os.environ.get('DOCKER_LEARNER_IMAGE')
 
 
-def test_get_image_name_returns_correct_image_for_Instructor_role(setup_image_environ, mock_jhub_user
-):
+def test_get_image_name_returns_correct_image_for_Instructor_role(setup_image_environ, mock_jhub_user):
     """
     Does the internal get_image_name method return instructor image when using the Instructor role?
     """
@@ -46,8 +43,7 @@ def test_get_image_name_returns_correct_image_for_Instructor_role(setup_image_en
     assert sut._get_image_name() == os.environ.get('DOCKER_INSTRUCTOR_IMAGE')
 
 
-def test_get_image_name_returns_Standard_image_for_unknown_role(setup_image_environ, mock_jhub_user
-):
+def test_get_image_name_returns_Standard_image_for_unknown_role(setup_image_environ, mock_jhub_user):
     """
     Does the internal get_image_name method return Standard image when using an unknown role?
     """
@@ -85,7 +81,7 @@ async def test_get_image_name_returns_correct_image_for_theia_workspace_type(
     """
     sut = IllumiDeskWorkSpaceDockerSpawner()
     sut.user = mock_jhub_user()
-    auth_state_dict['auth_state']['workspace_type'] = 'theia'    
+    auth_state_dict['auth_state']['workspace_type'] = 'theia'
     # call our hook to set the environment in the spawner and pass into it the auth_state
     await sut.run_auth_state_hook(auth_state_dict['auth_state'])
     assert sut._get_image_name() == os.environ.get(

--- a/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
+++ b/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
@@ -69,7 +69,7 @@ async def test_get_image_name_returns_correct_image_for_rstudio_workspace_type(
     sut.user = mock_jhub_user()
     auth_state_dict['auth_state']['workspace_type'] = 'rstudio'
     # call our hook to set the environment in the spawner and pass into it the auth_state
-    await sut.auth_state_hook(auth_state_dict['auth_state'])
+    await sut.run_auth_state_hook(auth_state_dict['auth_state'])
 
     assert sut._get_image_name() == os.environ.get(
         'DOCKER_RSTUDIO_IMAGE'
@@ -87,7 +87,7 @@ async def test_get_image_name_returns_correct_image_for_theia_workspace_type(
     sut.user = mock_jhub_user()
     auth_state_dict['auth_state']['workspace_type'] = 'theia'    
     # call our hook to set the environment in the spawner and pass into it the auth_state
-    await sut.auth_state_hook(auth_state_dict['auth_state'])
+    await sut.run_auth_state_hook(auth_state_dict['auth_state'])
     assert sut._get_image_name() == os.environ.get(
         'DOCKER_THEIA_IMAGE'
     )
@@ -104,7 +104,7 @@ async def test_get_image_name_returns_correct_image_for_vscode_workspace_type(
     sut.user = mock_jhub_user()
     auth_state_dict['auth_state']['workspace_type'] = 'vscode'
     # call our hook to set the environment in the spawner and pass into it the auth_state
-    await sut.auth_state_hook(auth_state_dict['auth_state'])
+    await sut.run_auth_state_hook(auth_state_dict['auth_state'])
 
     assert sut._get_image_name() == os.environ.get(
         'DOCKER_VSCODE_IMAGE'
@@ -122,7 +122,7 @@ async def test_get_image_name_returns_correct_image_for_notebook_workspace_type(
     sut.user = mock_jhub_user()
     auth_state_dict['auth_state']['workspace_type'] = 'notebook'
     # call our hook to set the environment in the spawner and pass into it the auth_state
-    await sut.auth_state_hook(auth_state_dict['auth_state'])
+    await sut.run_auth_state_hook(auth_state_dict['auth_state'])
 
     assert sut._get_image_name() == os.environ.get(
         'DOCKER_STANDARD_IMAGE'
@@ -142,7 +142,7 @@ async def test_get_image_name_returns_default_image_for_empty_workspace_type(
     # remove the `workspace_type` key
     del auth_state_dict['auth_state']['workspace_type']
     # call our hook to set the environment in the spawner and pass into it the auth_state
-    await sut.auth_state_hook(auth_state_dict['auth_state'])
+    await sut.run_auth_state_hook(auth_state_dict['auth_state'])
 
     assert sut._get_image_name() == os.environ.get(
         'DOCKER_STANDARD_IMAGE'

--- a/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
+++ b/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
@@ -8,9 +8,7 @@ from illumidesk.spawners.spawners import IllumiDeskRoleDockerSpawner
 from illumidesk.spawners.spawners import IllumiDeskWorkSpaceDockerSpawner
 
 
-def test_get_image_name_returns_correct_image_for_student_role(
-    setup_image_environ, mock_jhub_user
-):
+def test_get_image_name_returns_correct_image_for_student_role(setup_image_environ, mock_jhub_user):
     """
     Does the internal get_image_name method return the correct image with the student role?
     """
@@ -67,9 +65,7 @@ async def test_get_image_name_returns_correct_image_for_rstudio_workspace_type(
     # call our hook to set the environment in the spawner and pass into it the auth_state
     await sut.run_auth_state_hook(auth_state_dict['auth_state'])
 
-    assert sut._get_image_name() == os.environ.get(
-        'DOCKER_RSTUDIO_IMAGE'
-    )
+    assert sut._get_image_name() == os.environ.get('DOCKER_RSTUDIO_IMAGE')
 
 
 @pytest.mark.asyncio
@@ -84,9 +80,7 @@ async def test_get_image_name_returns_correct_image_for_theia_workspace_type(
     auth_state_dict['auth_state']['workspace_type'] = 'theia'
     # call our hook to set the environment in the spawner and pass into it the auth_state
     await sut.run_auth_state_hook(auth_state_dict['auth_state'])
-    assert sut._get_image_name() == os.environ.get(
-        'DOCKER_THEIA_IMAGE'
-    )
+    assert sut._get_image_name() == os.environ.get('DOCKER_THEIA_IMAGE')
 
 
 @pytest.mark.asyncio
@@ -102,9 +96,7 @@ async def test_get_image_name_returns_correct_image_for_vscode_workspace_type(
     # call our hook to set the environment in the spawner and pass into it the auth_state
     await sut.run_auth_state_hook(auth_state_dict['auth_state'])
 
-    assert sut._get_image_name() == os.environ.get(
-        'DOCKER_VSCODE_IMAGE'
-    )
+    assert sut._get_image_name() == os.environ.get('DOCKER_VSCODE_IMAGE')
 
 
 @pytest.mark.asyncio
@@ -120,9 +112,7 @@ async def test_get_image_name_returns_correct_image_for_notebook_workspace_type(
     # call our hook to set the environment in the spawner and pass into it the auth_state
     await sut.run_auth_state_hook(auth_state_dict['auth_state'])
 
-    assert sut._get_image_name() == os.environ.get(
-        'DOCKER_STANDARD_IMAGE'
-    )
+    assert sut._get_image_name() == os.environ.get('DOCKER_STANDARD_IMAGE')
 
 
 @pytest.mark.asyncio
@@ -140,9 +130,7 @@ async def test_get_image_name_returns_default_image_for_empty_workspace_type(
     # call our hook to set the environment in the spawner and pass into it the auth_state
     await sut.run_auth_state_hook(auth_state_dict['auth_state'])
 
-    assert sut._get_image_name() == os.environ.get(
-        'DOCKER_STANDARD_IMAGE'
-    )
+    assert sut._get_image_name() == os.environ.get('DOCKER_STANDARD_IMAGE')
 
 
 def test_dockerspawner_uses_raw_username_in_format_volume_name():

--- a/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
+++ b/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
@@ -1,4 +1,5 @@
 import os
+from os import environ
 import pytest
 import types
 
@@ -9,56 +10,49 @@ from illumidesk.spawners.spawners import IllumiDeskWorkSpaceDockerSpawner
 
 
 def test_get_image_name_uses_correct_image_with_student_role_in_user_environment(
-    monkeypatch, setup_image_environ, mock_user
+    setup_image_environ, mock_jhub_user
 ):
     """
     Does the internal image_from_role set the correct image with the student role?
     """
     sut = IllumiDeskRoleDockerSpawner()
-    attrs = {'name': 'foo', 'environment': {'USER_ROLE': 'Student'}}
-    mock_user.configure_mock(**attrs)
+    mock_user = mock_jhub_user(environ={'USER_ROLE': 'Student'})
     sut.user = mock_user
 
-    assert sut._image_from_role(mock_user.environment.get('USER_ROLE')) == os.environ.get('DOCKER_LEARNER_IMAGE')
+    assert sut._get_image_name() == os.environ.get('DOCKER_LEARNER_IMAGE')
 
 
-def test_get_image_name_uses_correct_image_with_learner_role_in_user_environment(
-    monkeypatch, setup_image_environ, mock_user
+def test_get_image_name_uses_correct_image_with_learner_role_in_user_environment(setup_image_environ, mock_jhub_user
 ):
     """
     Does the internal image_from_role method return student image when using the Student role?
     """
     sut = IllumiDeskRoleDockerSpawner()
-    attrs = {'name': 'foo', 'environment': {'USER_ROLE': 'Learner'}}
-    mock_user.configure_mock(**attrs)
+    mock_user = mock_jhub_user(environ={'USER_ROLE': 'Learner'})
     sut.user = mock_user
 
-    assert sut._image_from_role(mock_user.environment.get('USER_ROLE')) == os.environ.get('DOCKER_LEARNER_IMAGE')
+    assert sut._get_image_name() == os.environ.get('DOCKER_LEARNER_IMAGE')
 
 
-def test_get_image_name_uses_correct_image_with_instructor_role_in_user_environment(
-    monkeypatch, setup_image_environ, mock_user
+def test_get_image_name_uses_correct_image_with_instructor_role_in_user_environment(setup_image_environ, mock_jhub_user
 ):
     """
     Does the internal image_from_role method return instructor image when using the Instructor role?
     """
     sut = IllumiDeskRoleDockerSpawner()
-    attrs = {'name': 'foo', 'environment': {'USER_ROLE': 'Instructor'}}
-    mock_user.configure_mock(**attrs)
+    mock_user = mock_jhub_user(environ={'USER_ROLE': 'Instructor'})
     sut.user = mock_user
 
-    assert sut._image_from_role(mock_user.environment.get('USER_ROLE')) == os.environ.get('DOCKER_INSTRUCTOR_IMAGE')
+    assert sut._get_image_name() == os.environ.get('DOCKER_INSTRUCTOR_IMAGE')
 
 
 @pytest.mark.asyncio
-async def test_ensure_environment_assigned_to_user_role_from_auth_state_in_user_environment(
-    monkeypatch, auth_state_dict
+async def test_ensure_environment_assigned_to_user_role_from_auth_state_in_user_environment(auth_state_dict
 ):
     """
     Does the user's docker container environment reflect his/her role?
     """
     sut = IllumiDeskRoleDockerSpawner()
-    monkeypatch.setitem(auth_state_dict['auth_state'], 'user_role', 'Learner')
 
     await sut.auth_state_hook(sut, auth_state_dict['auth_state'])
     assert sut.environment['USER_ROLE'] == 'Learner'
@@ -72,7 +66,6 @@ async def test_get_image_name_uses_correct_image_for_rstudio_workspace_type(
     Does the user's docker container environment reflect the rstudio workspace?
     """
     sut = IllumiDeskWorkSpaceDockerSpawner()
-    monkeypatch.setitem(auth_state_dict['auth_state'], 'workspace_type', 'rstudio')
     attrs = {'name': 'foo', 'environment': {'USER_WORKSPACE_TYPE': 'rstudio'}}
     mock_user.configure_mock(**attrs)
     sut.user = mock_user
@@ -145,12 +138,13 @@ async def test_get_image_name_uses_correct_image_for_empty_workspace_type(
     it's set to empty?
     """
     sut = IllumiDeskWorkSpaceDockerSpawner()
-    monkeypatch.setitem(auth_state_dict['auth_state'], 'workspace_type', '')
-    attrs = {'name': 'foo', 'environment': {'USER_WORKSPACE_TYPE': 'notebook'}}
+    workspace_type = 'notebook'
+    mock_user.environment.get('USER_WORKSPACE_TYPE')
+    attrs = {'name': 'foo', 'environment': {'USER_WORKSPACE_TYPE': workspace_type}}
     mock_user.configure_mock(**attrs)
     sut.user = mock_user
 
-    assert sut._image_from_workspace_type(mock_user.environment.get('USER_WORKSPACE_TYPE')) == os.environ.get(
+    assert sut._get_image_name() == os.environ.get(
         'DOCKER_STANDARD_IMAGE'
     )
 


### PR DESCRIPTION
Create a base class with:
- Definition of `start` method to spawn a docker with a specific image (based on the auth_state or the environ)
- Force to use the both hooks (auth_state and pre_spawn) to reduce the logic in the child classes
- Separate the hooks functions

Closes #182 