### PR TITLE
Update setup course service default CMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ By default, this setup uses the `FirstUseAuthenticator` and as such accepts any 
 
 * **JupyterHub**: Runs [JupyterHub](https://jupyterhub.readthedocs.org/en/latest/getting-started.html#overview) within a Docker container running as root.
 
+* **Setup Course Image**: This image uses the built JupyterHub custom image as the base image (basically to avoid having to re install common dependencies). This image uses the [Quart](https://pgjones.gitlab.io/quart/) web server to communicate with the JupyterHub to scaffold host directories, launch shared grader notebooks as JupyterHub services, and updated configurations. This service is only applicable when using either LTI 1.1 or LTI 1.3 authenticators.
+
 * **Authenticator**: Authentication service. This setup relies on the [FirstUseAuthenticator](https://github.com/jupyterhub/firstuseauthenticator).
 
 * **Spawner**: Spawning service to manage user notebooks. This setup uses classes which inherit from the [DockerSpawner](https://github.com/jupyterhub/dockerspawner) class.

--- a/ansible/roles/jupyterhub/templates/Dockerfile.jhub.j2
+++ b/ansible/roles/jupyterhub/templates/Dockerfile.jhub.j2
@@ -27,11 +27,11 @@ WORKDIR /tmp
 
 # Install packages from requirements file
 COPY jupyterhub-requirements.txt /tmp/jupyterhub/requirements.txt
-RUN python3.8 -m pip install --no-cache -r /tmp/jupyterhub/requirements.txt
+RUN python3 -m pip install --no-cache -r /tmp/jupyterhub/requirements.txt
 
 # Install illumidesk package
 COPY illumidesk.zip /tmp/illumidesk.zip
-RUN python3.8 -m pip install --no-cache /tmp/illumidesk.zip
+RUN python3 -m pip install --no-cache /tmp/illumidesk.zip
 
 # Copy logo and favicon
 COPY illumidesk-80.png /usr/local/share/jupyterhub/static/images/illumidesk-80.png
@@ -54,6 +54,6 @@ RUN chmod +x /srv/jupyterhub/wait-for-postgres.sh
 
 # Run standard command but wait for postgres
 # https://docs.docker.com/compose/startup-order/
-CMD ["/srv/jupyterhub/wait-for-postgres.sh", "python3.8", "jupyterhub", "-f", "/etc/jupyterhub/jupyterhub_config.py"]
+CMD ["/srv/jupyterhub/wait-for-postgres.sh", "python3", "jupyterhub", "-f", "/etc/jupyterhub/jupyterhub_config.py"]
 
 HEALTHCHECK CMD curl --fail http://localhost:8081/ || exit 1

--- a/ansible/roles/setup_course/files/Dockerfile
+++ b/ansible/roles/setup_course/files/Dockerfile
@@ -9,4 +9,6 @@ RUN python3 -m pip install --no-cache-dir \
 
 EXPOSE 8000
 
+CMD ["hypercorn", "--bind", "0.0.0.0:8000", "--workers", "1", "illumidesk.setup_course.app:app"]
+
 HEALTHCHECK CMD curl --fail http://localhost:8000/config || exit 1


### PR DESCRIPTION
Add default CMD to the setup-course image to facilitate testing with standard `docker run ...` commands.

Closes #194 