### PR TITLE
Update setup-course microservice to use py3.8

### DIFF
--- a/ansible/roles/jupyterhub/files/requirements.txt
+++ b/ansible/roles/jupyterhub/files/requirements.txt
@@ -19,9 +19,6 @@ oauthenticator==0.11.0
 dockerspawner==0.11.1
 git+git://github.com/jupyterhub/wrapspawner.git@94b779af3926a90be922356bb9ab18153b918733
 
-# Setup course service
-quart==0.11.5
-
 # Utils
 filelock==3.0.12
 josepy==1.3.0

--- a/ansible/roles/setup_course/files/requirements.txt
+++ b/ansible/roles/setup_course/files/requirements.txt
@@ -1,0 +1,3 @@
+docker-compose==1.26.2
+Hypercorn==0.10.1
+quart==0.12.0

--- a/ansible/roles/setup_course/tasks/main.yml
+++ b/ansible/roles/setup_course/tasks/main.yml
@@ -1,8 +1,13 @@
 ---
-- name: copy setup-course dockerfile
+- name: create setup-course dockerfile from template
   template:
     src: Dockerfile.setup-course.j2
     dest: "{{ working_dir }}/Dockerfile.setup-course"
+
+- name: copy requirements.txt
+  copy:
+    src: requirements.txt
+    dest: "{{ working_dir }}/setup-course-requirements.txt"
 
 - name: create the setup course env var file from template
   template:

--- a/ansible/roles/setup_course/tasks/main.yml
+++ b/ansible/roles/setup_course/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: copy setup-course dockerfile
-  copy:
-    src: Dockerfile
+  template:
+    src: Dockerfile.setup-course.j2
     dest: "{{ working_dir }}/Dockerfile.setup-course"
 
 - name: create the setup course env var file from template

--- a/ansible/roles/setup_course/templates/Dockerfile.setup-course.j2
+++ b/ansible/roles/setup_course/templates/Dockerfile.setup-course.j2
@@ -1,20 +1,19 @@
-ARG BASE_IMAGE={{docker_illumidesk_jhub_image}}
-FROM ${BASE_IMAGE}
+FROM python:3.8-buster
 
-# Uninstall Python - Make sure before going for it
-RUN apt purge remove python \
- && apt purge python3
+SHELL [ "/bin/bash", "-c" ]
 
-# Refresh the packages index and install python3.8
-RUN apt update \
- && add-apt-repository ppa:deadsnakes/ppa \
- && apt install python3.8
+WORKDIR /tmp
+
+# Install illumidesk package
+COPY illumidesk.zip /tmp/illumidesk.zip
+RUN python3 -m pip install --no-cache /tmp/illumidesk.zip \
+ && rm /tmp/illumidesk.zip
+ 
+COPY setup-course-requirements.txt /tmp/requirements.txt
+RUN python3 -m pip install --no-cache-dir \
+    -r /tmp/requirements.txt
 
 WORKDIR /usr/src/app
- 
-RUN python3 -m pip install --no-cache-dir \
-    docker-compose \
-    hypercorn
 
 EXPOSE 8000
 

--- a/ansible/roles/setup_course/templates/Dockerfile.setup-course.j2
+++ b/ansible/roles/setup_course/templates/Dockerfile.setup-course.j2
@@ -1,6 +1,15 @@
 ARG BASE_IMAGE={{docker_illumidesk_jhub_image}}
 FROM ${BASE_IMAGE}
 
+# Uninstall Python - Make sure before going for it
+RUN apt purge remove python \
+ && apt purge python3
+
+# Refresh the packages index and install python3.8
+RUN apt update \
+ && add-apt-repository ppa:deadsnakes/ppa \
+ && apt install python3.8
+
 WORKDIR /usr/src/app
  
 RUN python3 -m pip install --no-cache-dir \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,4 +10,5 @@ pytest-cov==2.10.0
 pytest-html==2.1.1
 pytest-metadata==1.10.0
 pytest-mock==3.1.1
+quart==0.12.0
 requests==2.24.0

--- a/src/setup.py
+++ b/src/setup.py
@@ -44,7 +44,6 @@ setup(
         'jwcrypto',
         'nbgrader>=0.6.1',
         'oauthenticator==0.11.0',
-        'quart==0.11.5',
         'pem==20.1.0',
         'PyJWT==1.7.1',
         'pyjwkest==1.4.2',


### PR DESCRIPTION
- Use the standard `python3.8-buster` image as a base image.
- Move pip dependencies to requirements.txt

#129 