### PR TITLE
Refactor normalize string method

### DIFF
--- a/src/illumidesk/authenticators/authenticator.py
+++ b/src/illumidesk/authenticators/authenticator.py
@@ -54,15 +54,18 @@ async def setup_course_hook(
     Returns:
         authentication (Required): updated authentication object
     """
+    lti_utils = LTIUtils()
+    jupyterhub_api = JupyterHubAPI()
+
     announcement_port = os.environ.get('ANNOUNCEMENT_SERVICE_PORT') or '8889'
     org = os.environ.get('ORGANIZATION_NAME')
     if not org:
         raise EnvironmentError('ORGANIZATION_NAME env-var is not set')
-    username = authentication['name']
+    # normalize the name and course_id strings in authentication dictionary
+    course_id = lti_utils.normalize_string(authentication['auth_state']['course_id'])
+    username = lti_utils.normalize_string(authentication['name'])
     lms_user_id = authentication['auth_state']['lms_user_id']
-    course_id = authentication['auth_state']['course_id']
     user_role = authentication['auth_state']['user_role']
-    jupyterhub_api = JupyterHubAPI()
     # TODO: verify the logic to simplify groups creation and membership
     if user_role == 'Student' or user_role == 'Learner':
         # assign the user to 'nbgrader-<course_id>' group in jupyterhub and gradebook
@@ -172,8 +175,7 @@ class LTI11Authenticator(LTIAuthenticator):
             # runs as a docker container we need to normalize the string so we can use it
             # as a container name.
             if 'context_label' in args and args['context_label'] is not None:
-                course_label = args['context_label']
-                course_id = lti_utils.normalize_name_for_containers(course_label)
+                course_id = args['context_label']
                 self.log.debug('Course context_label normalized to: %s' % course_id)
             else:
                 raise HTTPError(400, 'Course label not included in the LTI request')
@@ -334,19 +336,17 @@ class LTI13Authenticator(OAuthenticator):
         self.log.debug('Decoded JWT is %s' % jwt_decoded)
 
         if validator.validate_launch_request(jwt_decoded):
-            course_id = lti_utils.normalize_name_for_containers(
-                jwt_decoded['https://purl.imsglobal.org/spec/lti/claim/context']['label']
-            )
+            course_id = jwt_decoded['https://purl.imsglobal.org/spec/lti/claim/context']['label']
             self.log.debug('Normalized course label is %s' % course_id)
             username = ''
             if 'email' in jwt_decoded.keys() and jwt_decoded.get('email'):
                 username = lti_utils.email_to_username(jwt_decoded['email'])
             elif 'name' in jwt_decoded.keys() and jwt_decoded.get('name'):
-                username = lti_utils.normalize_name_for_containers(jwt_decoded.get('name'))
+                username = jwt_decoded.get('name')
             elif 'given_name' in jwt_decoded.keys() and jwt_decoded.get('given_name'):
-                username = lti_utils.normalize_name_for_containers(jwt_decoded.get('given_name'))
+                username = jwt_decoded.get('given_name')
             elif 'family_name' in jwt_decoded.keys() and jwt_decoded.get('family_name'):
-                username = lti_utils.normalize_name_for_containers(jwt_decoded.get('family_name'))
+                username = jwt_decoded.get('family_name')
             elif (
                 'person_sourcedid' in jwt_decoded['https://purl.imsglobal.org/spec/lti/claim/lis']
                 and jwt_decoded['https://purl.imsglobal.org/spec/lti/claim/lis']['person_sourcedid']

--- a/src/illumidesk/authenticators/utils.py
+++ b/src/illumidesk/authenticators/utils.py
@@ -15,7 +15,7 @@ class LTIUtils(LoggingConfigurable):
     which work in conjunction with LTI requests.
     """
 
-    def normalize_name_for_containers(self, name: str) -> str:
+    def normalize_string(self, name: str) -> str:
         """
         Function used to strip special characters and convert strings
         to docker container compatible names. This function is used mostly

--- a/src/illumidesk/grades/handlers.py
+++ b/src/illumidesk/grades/handlers.py
@@ -26,7 +26,7 @@ class SendGradesHandler(BaseHandler):
         LTI authenticator version (1.1 or 1.3).
         
         Arguments:
-          course_id: course name which has been previously normalized by the LTIUtils.normalize_name_for_containers
+          course_id: course name which has been previously normalized by the LTIUtils.normalize_string
             function.
           assignment_name: assignment name which should coincide with the assignment name within the LMS.
           

--- a/src/tests/illumidesk/authenticators/test_lti13_authenticator.py
+++ b/src/tests/illumidesk/authenticators/test_lti13_authenticator.py
@@ -117,8 +117,7 @@ async def test_authenticator_returns_username_in_auth_state_with_with_name(monke
     ):
         with patch.object(LTI13LaunchValidator, 'validate_launch_request', return_value=True):
             result = await authenticator.authenticate(request_handler, None)
-            auth_state_dict['name'] = 'Foo'
-            assert result['name'] == auth_state_dict['name']
+            assert result['name'] == 'Foo'
 
 
 @pytest.mark.asyncio

--- a/src/tests/illumidesk/authenticators/test_lti13_authenticator.py
+++ b/src/tests/illumidesk/authenticators/test_lti13_authenticator.py
@@ -132,8 +132,7 @@ async def test_authenticator_returns_username_in_auth_state_with_with_given_name
     ):
         with patch.object(LTI13LaunchValidator, 'validate_launch_request', return_value=True):
             result = await authenticator.authenticate(request_handler, None)
-            auth_state_dict['name'] = 'Foo Bar'
-            assert result['name'] == auth_state_dict['name']
+            assert result['name'] == 'Foo Bar'
 
 
 @pytest.mark.asyncio

--- a/src/tests/illumidesk/authenticators/test_lti13_authenticator.py
+++ b/src/tests/illumidesk/authenticators/test_lti13_authenticator.py
@@ -117,8 +117,7 @@ async def test_authenticator_returns_username_in_auth_state_with_with_name(monke
     ):
         with patch.object(LTI13LaunchValidator, 'validate_launch_request', return_value=True):
             result = await authenticator.authenticate(request_handler, None)
-            monkeypatch.setitem(auth_state_dict, 'name', 'foo')
-
+            auth_state_dict['name'] = 'Foo'
             assert result['name'] == auth_state_dict['name']
 
 
@@ -134,8 +133,7 @@ async def test_authenticator_returns_username_in_auth_state_with_with_given_name
     ):
         with patch.object(LTI13LaunchValidator, 'validate_launch_request', return_value=True):
             result = await authenticator.authenticate(request_handler, None)
-            monkeypatch.setitem(auth_state_dict, 'name', 'foobar')
-
+            auth_state_dict['name'] = 'Foo Bar'
             assert result['name'] == auth_state_dict['name']
 
 
@@ -151,8 +149,7 @@ async def test_authenticator_returns_username_in_auth_state_with_family_name(mon
     ):
         with patch.object(LTI13LaunchValidator, 'validate_launch_request', return_value=True):
             result = await authenticator.authenticate(request_handler, None)
-            monkeypatch.setitem(auth_state_dict, 'name', 'bar')
-
+            auth_state_dict['name'] = 'Bar'
             assert result['name'] == auth_state_dict['name']
 
 

--- a/src/tests/illumidesk/authenticators/test_setup_course_hook.py
+++ b/src/tests/illumidesk/authenticators/test_setup_course_hook.py
@@ -61,7 +61,6 @@ async def test_setup_course_hook_calls_normalize_strings(
     """
     Does the setup_course_hook return normalized strings for the username and the course_id?
     """
-    local_utils = LTIUtils()
     local_authenticator = Authenticator(post_auth_hook=setup_course_hook)
     local_handler = mock_handler(RequestHandler, authenticator=local_authenticator)
     local_authentication = auth_state_dict

--- a/src/tests/illumidesk/authenticators/test_setup_course_hook.py
+++ b/src/tests/illumidesk/authenticators/test_setup_course_hook.py
@@ -15,6 +15,7 @@ from illumidesk.authenticators.authenticator import LTI11Authenticator
 from illumidesk.authenticators.authenticator import LTI13Authenticator
 from illumidesk.authenticators.authenticator import setup_course_hook
 from illumidesk.apis.jupyterhub_api import JupyterHubAPI
+from illumidesk.authenticators.utils import LTIUtils
 
 from tests.illumidesk.mocks import mock_handler
 from tests.illumidesk.factory import factory_auth_state_dict
@@ -51,6 +52,28 @@ async def test_setup_course_hook_raises_environment_error_with_missing_org(monke
     local_authentication = factory_auth_state_dict()
     with pytest.raises(EnvironmentError):
         await local_authenticator.post_auth_hook(local_authenticator, local_handler, local_authentication)
+
+
+@pytest.mark.asyncio()
+async def test_setup_course_hook_calls_normalize_strings(
+    auth_state_dict, setup_course_environ, setup_course_hook_environ
+):
+    """
+    Does the setup_course_hook return normalized strings for the username and the course_id?
+    """
+    local_utils = LTIUtils()
+    local_authenticator = Authenticator(post_auth_hook=setup_course_hook)
+    local_handler = mock_handler(RequestHandler, authenticator=local_authenticator)
+    local_authentication = auth_state_dict
+
+    with patch.object(LTIUtils, 'normalize_string', return_value='intro101') as mock_normalize_string:
+        with patch.object(JupyterHubAPI, 'add_student_to_jupyterhub_group', return_value=None):
+            with patch.object(JupyterHubAPI, 'add_user_to_nbgrader_gradebook', return_value=None):
+                with patch.object(
+                    AsyncHTTPClient, 'fetch', return_value=factory_http_response(handler=local_handler.request)
+                ):
+                    _ = await setup_course_hook(local_authenticator, local_handler, local_authentication)
+                    assert mock_normalize_string.called
 
 
 @pytest.mark.asyncio()

--- a/src/tests/illumidesk/authenticators/test_utils.py
+++ b/src/tests/illumidesk/authenticators/test_utils.py
@@ -9,62 +9,62 @@ from unittest.mock import Mock
 from illumidesk.authenticators.utils import LTIUtils
 
 
-def test_normalize_name_for_containers_raises_value_error_with_missing_name():
+def test_normalize_string_raises_value_error_with_missing_name():
     """
     Does a missing container name raise a value error?
     """
     container_name = ''
     utils = LTIUtils()
     with pytest.raises(ValueError):
-        normalized_container_name = utils.normalize_name_for_containers(container_name)
+        normalized_container_name = utils.normalize_string(container_name)
 
 
-def test_normalize_name_for_containers_return_false_with_missing_name():
+def test_normalize_string_return_false_with_missing_name():
     """
     Does a missing container name raise a value error?
     """
     container_name = ''
     utils = LTIUtils()
     with pytest.raises(ValueError):
-        normalized_container_name = utils.normalize_name_for_containers(container_name)
+        normalized_container_name = utils.normalize_string(container_name)
 
 
-def test_normalize_name_for_containers_with_long_name():
+def test_normalize_string_with_long_name():
     """
     Does a container name with more than 20 characters get normalized?
     """
     container_name = 'this_is_a_really_long_container_name'
     utils = LTIUtils()
-    normalized_container_name = utils.normalize_name_for_containers(container_name)
+    normalized_container_name = utils.normalize_string(container_name)
 
     assert len(normalized_container_name) <= 20
 
 
-def test_normalize_name_for_containers_with_special_characters():
+def test_normalize_string_with_special_characters():
     """
     Does a container name with with special characters get normalized?
     """
     container_name = '#$%_this_is_a_container_name'
     utils = LTIUtils()
-    normalized_container_name = utils.normalize_name_for_containers(container_name)
+    normalized_container_name = utils.normalize_string(container_name)
     regex = re.compile('[@!#$%^&*()<>?/\\|}{~:]')
 
     assert regex.search(normalized_container_name) is None
 
 
-def test_normalize_name_for_containers_with_first_letter_as_alphanumeric():
+def test_normalize_string_with_first_letter_as_alphanumeric():
     """
     Does a container name with start with an alphanumeric character?
     """
     container_name = '___this_is_a_container_name'
     utils = LTIUtils()
-    normalized_container_name = utils.normalize_name_for_containers(container_name)
+    normalized_container_name = utils.normalize_string(container_name)
     regex = re.compile('_.-')
     first_character = normalized_container_name[0]
     assert first_character != regex.search(normalized_container_name)
 
 
-def test_normalize_name_for_containers_raises_value_error_with_missing_name():
+def test_normalize_string_raises_value_error_with_missing_name():
     """
     Does a missing container name raise a value error?
     """
@@ -72,7 +72,7 @@ def test_normalize_name_for_containers_raises_value_error_with_missing_name():
     utils = LTIUtils()
 
     with pytest.raises(ValueError):
-        utils.normalize_name_for_containers(container_name)
+        utils.normalize_string(container_name)
 
 
 def test_get_protocol_with_more_than_one_value():


### PR DESCRIPTION
- Change `normalize_name_for_containers` to `normalize_string`
- Move normalize string tasks (username and course id) to setup_course_hook
- Update tests

#198 