### PR TITLE
Refactor authenticators to always normalize usernames

### DIFF
--- a/src/illumidesk/authenticators/authenticator.py
+++ b/src/illumidesk/authenticators/authenticator.py
@@ -238,7 +238,6 @@ class LTI11Authenticator(LTIAuthenticator):
                     username = args['user_id']
                 else:
                     raise HTTPError(400, 'Unable to get username from request arguments')
-            self.log.debug('Assigned username is: %s' % username)
 
             # use the user_id to identify the unique user id, if its not sent with the request
             # then default to the username
@@ -261,8 +260,12 @@ class LTI11Authenticator(LTIAuthenticator):
                         assignment_name, lis_outcome_service_url, lms_user_id, lis_result_sourcedid
                     )
 
+            # ensure the user name is normalized
+            username_normalized = lti_utils.normalize_string(username)
+            self.log.debug('Assigned username is: %s' % username_normalized)
+
             return {
-                'name': username,
+                'name': username_normalized,
                 'auth_state': {
                     'course_id': course_id,
                     'lms_user_id': lms_user_id,
@@ -354,6 +357,8 @@ class LTI13Authenticator(OAuthenticator):
                 username = jwt_decoded['https://purl.imsglobal.org/spec/lti/claim/lis']['person_sourcedid'].lower()
             if username == '':
                 raise HTTPError('Unable to set the username')
+            # ensure the username is normalized
+            username_normalized = lti_utils.normalize_string(username)
             self.log.debug('username is %s' % username)
 
             # assign a workspace type, if provided, otherwise defaults to jupyter classic nb
@@ -389,8 +394,12 @@ class LTI13Authenticator(OAuthenticator):
             if 'https://purl.imsglobal.org/spec/lti-ags/claim/endpoint' in jwt_decoded:
                 course_lineitems = jwt_decoded['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']['lineitems']
 
+            # ensure the user name is normalized
+            username_normalized = lti_utils.normalize_string(username)
+            self.log.debug('Assigned username is: %s' % username_normalized)
+
             return {
-                'name': username,
+                'name': username_normalized,
                 'auth_state': {
                     'course_id': course_id,
                     'user_role': user_role,

--- a/src/tests/illumidesk/authenticators/test_lti13_authenticator.py
+++ b/src/tests/illumidesk/authenticators/test_lti13_authenticator.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from illumidesk.authenticators.validator import LTI13LaunchValidator
 from illumidesk.authenticators.authenticator import LTI13Authenticator
+from illumidesk.authenticators.authenticator import LTIUtils
 
 
 @pytest.mark.asyncio
@@ -58,6 +59,24 @@ async def test_authenticator_invokes_lti13validator_validate_launch_request(
         ) as mock_verify_authentication_request:
             _ = await authenticator.authenticate(request_handler, None)
             assert mock_verify_authentication_request.called
+
+
+@pytest.mark.asyncio
+async def test_authenticator_invokes_lti_utils_normalize_string(
+    make_lti13_resource_link_request, build_lti13_jwt_id_token, make_mock_request_handler
+):
+    """
+    Does the authenticator invoke the LTIUtils normalize_string method?
+    """
+    authenticator = LTI13Authenticator()
+    request_handler = make_mock_request_handler(RequestHandler, authenticator=authenticator)
+    with patch.object(
+        RequestHandler, 'get_argument', return_value=build_lti13_jwt_id_token(make_lti13_resource_link_request)
+    ):
+        with patch.object(LTI13LaunchValidator, 'validate_launch_request', return_value=True):
+            with patch.object(LTIUtils, 'normalize_string', return_value=True) as mock_normalize_string:
+                _ = await authenticator.authenticate(request_handler, None)
+                assert mock_normalize_string.called
 
 
 @pytest.mark.asyncio
@@ -115,7 +134,7 @@ async def test_authenticator_returns_username_in_auth_state_with_with_name(
     ):
         with patch.object(LTI13LaunchValidator, 'validate_launch_request', return_value=True):
             result = await authenticator.authenticate(request_handler, None)
-            assert result['name'] == 'Foo'
+            assert result['name'] == 'foo'
 
 
 @pytest.mark.asyncio
@@ -136,7 +155,7 @@ async def test_authenticator_returns_username_in_auth_state_with_with_given_name
     ):
         with patch.object(LTI13LaunchValidator, 'validate_launch_request', return_value=True):
             result = await authenticator.authenticate(request_handler, None)
-            assert result['name'] == 'Foo Bar'
+            assert result['name'] == 'foobar'
 
 
 @pytest.mark.asyncio
@@ -158,7 +177,7 @@ async def test_authenticator_returns_username_in_auth_state_with_family_name(
         with patch.object(LTI13LaunchValidator, 'validate_launch_request', return_value=True):
             result = await authenticator.authenticate(request_handler, None)
 
-            assert result['name'] == 'Family name'
+            assert result['name'] == 'familyname'
 
 
 @pytest.mark.asyncio

--- a/src/tests/illumidesk/authenticators/test_utils.py
+++ b/src/tests/illumidesk/authenticators/test_utils.py
@@ -9,16 +9,6 @@ from unittest.mock import Mock
 from illumidesk.authenticators.utils import LTIUtils
 
 
-def test_normalize_string_raises_value_error_with_missing_name():
-    """
-    Does a missing container name raise a value error?
-    """
-    container_name = ''
-    utils = LTIUtils()
-    with pytest.raises(ValueError):
-        normalized_container_name = utils.normalize_string(container_name)
-
-
 def test_normalize_string_return_false_with_missing_name():
     """
     Does a missing container name raise a value error?
@@ -26,7 +16,7 @@ def test_normalize_string_return_false_with_missing_name():
     container_name = ''
     utils = LTIUtils()
     with pytest.raises(ValueError):
-        normalized_container_name = utils.normalize_string(container_name)
+        utils.normalize_string(container_name)
 
 
 def test_normalize_string_with_long_name():


### PR DESCRIPTION
We don't always assign the `setup_course_hook` to the `auth_state_hook`, so it safer to normalize usernames before creating user containers.

#201 