### PR TITLE
Update LTI configs with admin user env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ cp ansible/hosts.example ansible/hosts
 
 By default this setup uses the `FristUseAuthenticator`. Refer to the [customization](#customization) section if you would like to use LTI 1.1 with your LMS.
 
+> **NOTE**: the default admin user is set to `admin`. To update this default value, change the `admin_user` variable to another username. Refere to the `hosts.example` file for example.
+
 4. Run the deployment script (the script will prompt you for certain values):
 
     ```bash

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -57,7 +57,7 @@ docker_proxy_image: "{{ docker_proxy_image_param | default('jupyterhub/configura
 jupyter_notebook_config: "{{ jupyter_notebook_config_param | default('jupyter_notebook_config.py') }}"
 
 # Admin users
-admin_user: "{{ admin_user_param | default('') }}"
+admin_user: "{{ admin_user_param | default('admin') }}"
 
 # Mount directories
 mnt_root: "{{ mnt_root_param | default('/mnt') }}"

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
@@ -146,7 +146,7 @@ c.LTIAuthenticator.consumers = {
 # Post auth hook to setup course
 c.Authenticator.post_auth_hook = setup_course_hook
 
-admin_user = os.environ.get('JUPYTERHUB_ADMIN_USERS')
+admin_user = os.environ.get('JUPYTERHUB_ADMIN_USER')
 # Add other admin users as needed
 c.Authenticator.admin_users = {
     admin_user,

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti13.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti13.py
@@ -161,7 +161,7 @@ c.JupyterHub.extra_handlers = [
 # Post auth hook to setup course
 c.Authenticator.post_auth_hook = setup_course_hook
 
-admin_user = os.environ.get('JUPYTERHUB_ADMIN_USERS')
+admin_user = os.environ.get('JUPYTERHUB_ADMIN_USER')
 # Add other admin users as needed
 c.Authenticator.admin_users = {
     admin_user,

--- a/src/tests/illumidesk/conftest.py
+++ b/src/tests/illumidesk/conftest.py
@@ -64,6 +64,7 @@ def jupyterhub_api_environ(monkeypatch):
     """
     monkeypatch.setenv('JUPYTERHUB_API_TOKEN', str(uuid.uuid4()))
     monkeypatch.setenv('JUPYTERHUB_API_URL', 'https://localhost/hub/api')
+    monkeypatch.setenv('JUPYTERHUB_ADMIN_USER', 'admin')
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
- Updates LTI configs to use `JUPYTERHUB_ADMIN_USER` instead `JUPYTERHUB_ADMIN_USERS`.
- Replaces `''` with `admin` for default admin user value
- Updated README.md with new setting callout

Closes #218 