### PR TITLE
Fix the response of /jwks endpoint

### DIFF
--- a/src/illumidesk/lti13/handlers.py
+++ b/src/illumidesk/lti13/handlers.py
@@ -115,4 +115,8 @@ class LTI13JWKSHandler(BaseHandler):
 
         jwk = get_jwk(public_key)
         self.log.debug('the jwks is %s' % jwk)
-        self.write(json.dumps(jwk))
+        keys_obj ={'keys': []}
+        keys_obj['keys'].append(jwk)
+        # we do not need to use json.dumps because tornado is converting our dict automatically and adding the content-type as json
+        # https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.write
+        self.write(keys_obj)

--- a/src/illumidesk/lti13/handlers.py
+++ b/src/illumidesk/lti13/handlers.py
@@ -115,7 +115,7 @@ class LTI13JWKSHandler(BaseHandler):
 
         jwk = get_jwk(public_key)
         self.log.debug('the jwks is %s' % jwk)
-        keys_obj ={'keys': []}
+        keys_obj = {'keys': []}
         keys_obj['keys'].append(jwk)
         # we do not need to use json.dumps because tornado is converting our dict automatically and adding the content-type as json
         # https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.write

--- a/src/tests/illumidesk/lti13/test_lti13_jwks_handler.py
+++ b/src/tests/illumidesk/lti13/test_lti13_jwks_handler.py
@@ -1,10 +1,13 @@
 from os import chmod
 from os import environ
+
 import pytest
 
 from illumidesk.lti13.handlers import LTI13JWKSHandler
 
 from tornado.web import RequestHandler
+
+from unittest.mock import patch
 
 
 @pytest.mark.asyncio
@@ -34,3 +37,31 @@ async def test_get_method_raises_an_error_without_lti13_private_key(make_mock_re
     config_handler = LTI13JWKSHandler(handler.application, handler.request)
     with pytest.raises(EnvironmentError):
         await config_handler.get()
+
+
+@patch('tornado.web.RequestHandler.write')
+def test_get_method_calls_write_method_with_a_dict(mock_write_method, lti_config_environ, make_mock_request_handler):
+    """
+    Does the write method is called with a dict?
+    """
+    handler = make_mock_request_handler(RequestHandler)
+    config_handler = LTI13JWKSHandler(handler.application, handler.request)
+
+    config_handler.get()
+    assert mock_write_method.called
+    write_args = mock_write_method.call_args[0]
+    # make sure we're passing a dict to let tornado convert it as json with the specific content-type
+    assert write_args[0]
+    assert type(write_args[0]) == dict
+
+
+def test_get_method_set_content_type_as_json(lti_config_environ, make_mock_request_handler):
+    """
+    Does the write method is set the content-type header as application/json?
+    """
+    handler = make_mock_request_handler(RequestHandler)
+    config_handler = LTI13JWKSHandler(handler.application, handler.request)
+
+    config_handler.get()
+    assert 'Content-Type' in config_handler._headers
+    assert 'application/json' in config_handler._headers['Content-type']


### PR DESCRIPTION
Use tornado's `self.write` method with the python dict (without parse a json) to automatically set *content-type* as json because the LMS does not recognize the response when it is only plain text

Ref: https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.write

Closes #204 