### PR TITLE
Update assignment name with LTI 1.1

### DIFF
--- a/src/illumidesk/authenticators/authenticator.py
+++ b/src/illumidesk/authenticators/authenticator.py
@@ -226,7 +226,6 @@ class LTI11Authenticator(LTIAuthenticator):
             # GRADES-SENDER: retrieve assignment_name from standard property vs custom lms
             # properties, such as custom_canvas_...
             assignment_name = ''
-            context_id = ''
             lis_outcome_service_url = ''
             lis_result_sourcedid = ''
             if lms_vendor == 'canvas':
@@ -234,9 +233,8 @@ class LTI11Authenticator(LTIAuthenticator):
                 if 'custom_canvas_assignment_title' in args and args['custom_canvas_assignment_title']:
                     assignment_name = lti_utils.normalize_string(args['custom_canvas_assignment_title'])
             else:
-                # edx includes the resource (assignment) within the context_id string
-                if 'context_id' in args and args['context_id']:
-                    assignment_name = context_id.split(':', 1)[1].split('+', 1)[0]
+                if 'context_label' in args and args['context_label']:
+                    assignment_name = args['context_label']
             if user_role == 'Learner' or user_role == 'Student':
                 # the next fields must come in args
                 if 'lis_outcome_service_url' in args and args['lis_outcome_service_url']:
@@ -245,6 +243,11 @@ class LTI11Authenticator(LTIAuthenticator):
                     lis_result_sourcedid = args['lis_result_sourcedid']
                 # only if both values exist we can register them to submit grades later
                 if lis_outcome_service_url and lis_result_sourcedid:
+                    # if the assignment name is still empty, fetch it from the resource_link_id
+                    if assignment_name == '':
+                        if 'resource_link_id' in args and args['resource_link_id']:
+                            assignment_name = args['resource_link_id']
+                    assignment_name = args['resource_link_id']
                     control_file = LTIGradesSenderControlFile(f'/home/grader-{course_id}/{course_id}')
                     control_file.register_data(
                         assignment_name, lis_outcome_service_url, lms_user_id, lis_result_sourcedid

--- a/src/tests/illumidesk/conftest.py
+++ b/src/tests/illumidesk/conftest.py
@@ -78,57 +78,6 @@ def lti_config_environ(monkeypatch, pem_file):
 
 
 @pytest.fixture(scope='function')
-def lti11_complete_launch_args():
-    """
-    Valid response when retrieving jwks from the platform.
-    """
-    args = {
-        'oauth_callback': ['about:blank'.encode()],
-        'oauth_consumer_key': ['my_consumer_key'.encode()],
-        'oauth_signature_method': ['HMAC-SHA1'.encode()],
-        'oauth_timestamp': ['1585947271'.encode()],
-        'oauth_nonce': ['01fy8HKIASKuD9gK9vWUcBj9fql1nOCWfOLPzeylsmg'.encode()],
-        'oauth_signature': ['abc123'.encode()],
-        'oauth_version': ['1.0'.encode()],
-        'context_id': ['888efe72d4bbbdf90619353bb8ab5965ccbe9b3f'.encode()],
-        'context_label': ['intro101'.encode()],
-        'context_title': ['intro101'.encode()],
-        'custom_canvas_assignment_title': ['test-assignment'.encode()],
-        'custom_canvas_user_login_id': ['student1'.encode()],
-        'custom_worskpace_type': ['foo'.encode()],
-        'ext_roles': ['urn:lti:instrole:ims/lis/Learner'.encode()],
-        'launch_presentation_document_target': ['iframe'.encode()],
-        'launch_presentation_height': ['1000'.encode()],
-        'launch_presentation_locale': ['en'.encode()],
-        'launch_presentation_return_url': [
-            'https: //illumidesk.instructure.com/courses/161/external_content/success/external_tool_redirect'.encode()
-        ],
-        'launch_presentation_width': ['1000'.encode()],
-        'lis_outcome_service_url': [
-            'http://www.imsglobal.org/developers/LTI/test/v1p1/common/tool_consumer_outcome.php?b64=MTIzNDU6OjpzZWNyZXQ='.encode()
-        ],
-        'lis_person_contact_email_primary': ['student1@example.com'.encode()],
-        'lis_person_name_family': ['Bar'.encode()],
-        'lis_person_name_full': ['Foo Bar'.encode()],
-        'lis_person_name_given': ['Foo'.encode()],
-        'lti_message_type': ['basic-lti-launch-request'.encode()],
-        'lis_result_sourcedid': ['feb-123-456-2929::28883'.encode()],
-        'lti_version': ['LTI-1p0'.encode()],
-        'resource_link_id': ['888efe72d4bbbdf90619353bb8ab5965ccbe9b3f'.encode()],
-        'resource_link_title': ['IllumiDesk'.encode()],
-        'roles': ['Learner'.encode()],
-        'tool_consumer_info_product_family_code': ['canvas'.encode()],
-        'tool_consumer_info_version': ['cloud'.encode()],
-        'tool_consumer_instance_contact_email': ['notifications@mylms.com'.encode()],
-        'tool_consumer_instance_guid': ['srnuz6h1U8kOMmETzoqZTJiPWzbPXIYkAUnnAJ4u:test-lms'.encode()],
-        'tool_consumer_instance_name': ['myorg'.encode()],
-        'user_id': ['185d6c59731a553009ca9b59ca3a885100000'.encode()],
-        'user_image': ['https://lms.example.com/avatar-50.png'.encode()],
-    }
-    return args
-
-
-@pytest.fixture(scope='function')
 def lti13_login_params():
     """
     Creates a dictionary with k/v's that emulates an initial login request.


### PR DESCRIPTION
- Fetch assignment name from `custom_canvas_assignment_title` if the LTI 1.1 launch request is initiated from Canvas. Otherwise, use the `context_label` (also used for course name) and if still empty use the `lti_resource_id`.