### PR TITLE
Fix to determine what authenticator is used to submit grades

### DIFF
--- a/src/illumidesk/grades/handlers.py
+++ b/src/illumidesk/grades/handlers.py
@@ -1,5 +1,4 @@
 import json
-from jupyterhub.auth import Authenticator
 
 from illumidesk.authenticators.authenticator import LTI11Authenticator
 from illumidesk.grades import exceptions
@@ -15,6 +14,7 @@ class SendGradesHandler(BaseHandler):
     """
     Defines a POST method to process grades submission for a specific assignment within a course
     """
+
     async def post(self, course_id: str, assignment_name: str) -> None:
         """
         Receives a request with the course name and the assignment name as path parameters

--- a/src/illumidesk/grades/handlers.py
+++ b/src/illumidesk/grades/handlers.py
@@ -36,8 +36,8 @@ class SendGradesHandler(BaseHandler):
 
         lti_grade_sender = None
 
-        # check lti version by the authenticator setting        
-        if self.authenticator is LTI11Authenticator:
+        # check lti version by the authenticator setting
+        if isinstance(self.authenticator, LTI11Authenticator) or self.authenticator is LTI11Authenticator:
             lti_grade_sender = LTIGradeSender(course_id, assignment_name)
         else:
             auth_state = await self.current_user.get_auth_state()

--- a/src/illumidesk/grades/handlers.py
+++ b/src/illumidesk/grades/handlers.py
@@ -1,4 +1,5 @@
 import json
+from jupyterhub.auth import Authenticator
 
 from illumidesk.authenticators.authenticator import LTI11Authenticator
 from illumidesk.grades import exceptions
@@ -14,11 +15,6 @@ class SendGradesHandler(BaseHandler):
     """
     Defines a POST method to process grades submission for a specific assignment within a course
     """
-
-    @property
-    def authenticator_class(self):
-        return self.settings.get('authenticator_class', None)
-
     async def post(self, course_id: str, assignment_name: str) -> None:
         """
         Receives a request with the course name and the assignment name as path parameters
@@ -40,8 +36,8 @@ class SendGradesHandler(BaseHandler):
 
         lti_grade_sender = None
 
-        # check lti version by the authenticator setting
-        if self.authenticator_class == LTI11Authenticator:
+        # check lti version by the authenticator setting        
+        if self.authenticator is LTI11Authenticator:
             lti_grade_sender = LTIGradeSender(course_id, assignment_name)
         else:
             auth_state = await self.current_user.get_auth_state()

--- a/src/tests/illumidesk/conftest.py
+++ b/src/tests/illumidesk/conftest.py
@@ -8,6 +8,7 @@ import time
 import uuid
 
 from Crypto.PublicKey import RSA
+from illumidesk.authenticators import authenticator
 
 from illumidesk.grades.sender_controlfile import LTIGradesSenderControlFile
 from illumidesk.authenticators.utils import LTIUtils

--- a/src/tests/illumidesk/conftest.py
+++ b/src/tests/illumidesk/conftest.py
@@ -8,7 +8,6 @@ import time
 import uuid
 
 from Crypto.PublicKey import RSA
-from illumidesk.authenticators import authenticator
 
 from illumidesk.grades.sender_controlfile import LTIGradesSenderControlFile
 from illumidesk.authenticators.utils import LTIUtils

--- a/src/tests/illumidesk/grades/test_lms_grades_handler.py
+++ b/src/tests/illumidesk/grades/test_lms_grades_handler.py
@@ -5,7 +5,6 @@ from tornado.web import RequestHandler
 from unittest.mock import AsyncMock
 from unittest.mock import Mock
 from unittest.mock import patch
-from unittest.mock import PropertyMock
 
 from illumidesk.authenticators.authenticator import LTI11Authenticator
 from illumidesk.authenticators.authenticator import LTI13Authenticator
@@ -52,13 +51,13 @@ async def test_SendGradesHandler_calls_authenticator_class_property(
     """
     with patch('illumidesk.grades.handlers.LTI13GradeSender') as mock_sender:
         instance = mock_sender.return_value
-        instance.send_grades = AsyncMock()        
+        instance.send_grades = AsyncMock()
         await send_grades_handler_lti13.post('course_example', 'assignment_test')
         assert mock_sender.called
 
         with patch('illumidesk.grades.handlers.LTIGradeSender') as mocklti11_sender:
             instance = mocklti11_sender.return_value
-            instance.send_grades = AsyncMock()            
+            instance.send_grades = AsyncMock()
             await send_grades_handler_lti11.post('course_example', 'assignment_test')
             mocklti11_sender.called
 


### PR DESCRIPTION
When LTI 11Authenticator was used as the authentication type, the SendGradesHandler class ignores the logic to send grades through lti11 
