### PR TITLE
Create a shared folder between instructors and students

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Click on the `Grader Console` tab and follow the steps available within the nbgr
 
 * **Workspaces**: User servers are set and launched based on either the user's LTI compatible role (student/learner group or instructor group) or by specifying the ?next=/user-redirect/<workspace_type> as a query parameter that identifies the workspace type by path, for example: next=/user-redirect/theia for the Theia IDE or next=/user-redirect/vscode for VS Code IDE.
 
-* **Shared drive**: An shared folder can be used to share files from the share grader service and the student notebooks.
+* **Shared drive**: A shared folder that may be used to share content among users within a course. Users with access to the course's shared grader notebook (Instructors and TAs) have read/write access to the files located in the shared folder. Users accessing their own workspaces have access to the files in the shared grader notebook with read-only access.
 
 ## Customization
 
@@ -152,9 +152,7 @@ With the Postgres container enabled, users (both students and instructors) can c
 
 ### Shared Folder
 
-Users that wish to use a shared folder between Instructors and Learners may do so by setting the `shared_folder_enabled` to true.
-
-With the Shared folder enabled, users with access to the grader service (instructors/TA) can create files directly in their `/shared` folder. Since each grader service is launched by each course so all the files created here must be reflected within the `/shared/<course_name>` in all the learner containers.
+With shared_folder_enabled set to true, users with access to the shared grader service (by default Instructors and TAs) may create files directly in the course's /shared folder. Since one shared grader notebook is launched for each course then all the files created in the /shared folder appear within the /shared/<course_name> in all end-user workspaces.
 
 ### Additional Workspace Types
 
@@ -464,7 +462,7 @@ The services included with this setup rely on environment variables to work prop
 | POSTGRES_USER | `string` | Postgres database username | `jupyterhub` |
 | POSTGRES_PASSWORD | `string` | Postgres database password | `jupyterhub` |
 | POSTGRES_HOST | `string` | Postgres host | `jupyterhub-db` |
-| SHARED_FOLDER_ENABLED | `string` | Specifies the use of shared folder (between grader and student notebooks)  | `False` |
+| SHARED_FOLDER_ENABLED | `string` | Specifies the use of shared folder (between grader and student notebooks)  | `True` |
 
 ### Environment Variables pertaining to setup-course service, located in `env.setup-course`
 
@@ -480,7 +478,7 @@ The services included with this setup rely on environment variables to work prop
 | MNT_ROOT | `string` | Notebook grader user id | `/mnt` |
 | NB_UID | `string` | Notebook grader user id | `10001` |
 | NB_GID | `string` | Notebook grader user id | `100` |
-| SHARED_FOLDER_ENABLED | `string` | Specifies the use of shared folder (between grader and student notebooks)  | `False` |
+| SHARED_FOLDER_ENABLED | `string` | Specifies the use of shared folder (between grader and student notebooks)  | `True` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Click on the `Grader Console` tab and follow the steps available within the nbgr
 
 * **Workspaces**: User servers are set and launched based on either the user's LTI compatible role (student/learner group or instructor group) or by specifying the ?next=/user-redirect/<workspace_type> as a query parameter that identifies the workspace type by path, for example: next=/user-redirect/theia for the Theia IDE or next=/user-redirect/vscode for VS Code IDE.
 
+* **Shared drive**: An shared folder can be used to share files from the share grader service and the student notebooks.
+
 ## Customization
 
 You may customize your setup by customizing additional variables in the `hosts` file. For example, you can run the `make deploy` command to set your own organization name and top level domain when using this setup behind a reverse-proxy with TLS termination.
@@ -147,6 +149,12 @@ Then, rerun the `make deploy` copmmand to update your stack's settings.
 > **New in Version 0.5.0**: users that wish to provide their Learners with a shared Postgres container my do so by setting the `postgres_labs_enabled` to true.
 
 With the Postgres container enabled, users (both students and instructors) can connect to a shared Postgres database from within their Jupyter Notebooks by opening a connection with the standard `psycop2g` depency using the `postgres-labs` host name. IllumiDesk's [user guides provide additional examples](https://docs.illumidesk.com) on the commands and common use-cases available for this option.
+
+### Shared Folder
+
+Users that wish to use a shared folder between Instructors and Learners may do so by setting the `shared_folder_enabled` to true.
+
+With the Shared folder enabled, users with access to the grader service (instructors/TA) can create files directly in their `/shared` folder. Since each grader service is launched by each course so all the files created here must be reflected within the `/shared/<course_name>` in all the learner containers.
 
 ### Additional Workspace Types
 
@@ -456,6 +464,7 @@ The services included with this setup rely on environment variables to work prop
 | POSTGRES_USER | `string` | Postgres database username | `jupyterhub` |
 | POSTGRES_PASSWORD | `string` | Postgres database password | `jupyterhub` |
 | POSTGRES_HOST | `string` | Postgres host | `jupyterhub-db` |
+| SHARED_FOLDER_ENABLED | `string` | Specifies the use of shared folder (between grader and student notebooks)  | `False` |
 
 ### Environment Variables pertaining to setup-course service, located in `env.setup-course`
 
@@ -471,6 +480,7 @@ The services included with this setup rely on environment variables to work prop
 | MNT_ROOT | `string` | Notebook grader user id | `/mnt` |
 | NB_UID | `string` | Notebook grader user id | `10001` |
 | NB_GID | `string` | Notebook grader user id | `100` |
+| SHARED_FOLDER_ENABLED | `string` | Specifies the use of shared folder (between grader and student notebooks)  | `False` |
 
 ---
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -63,4 +63,4 @@ lti13_token_url: "{{ lti13_token_url_param | default('https://illumidesk.instruc
 lti13_authorize_url: "{{ lti13_authorize_url_param | default('https://illumidesk.instructure.com/api/lti/authorize_redirect')}}"
 
 # shared drive
-shared_folder_enabled: "{{ shared_folder_enabled_param | default('true') }}"
+shared_folder_enabled: "{{ shared_folder_enabled_param | default('false') }}"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -61,3 +61,6 @@ lti13_private_key: "{{ lti13_private_key_param | default('/secrets/keys/rsa_priv
 lti13_endpoint: "{{ lti13_endpoint_param | default('https://illumidesk.instructure.com')}}"
 lti13_token_url: "{{ lti13_token_url_param | default('https://illumidesk.instructure.com/login/oauth2/token')}}"
 lti13_authorize_url: "{{ lti13_authorize_url_param | default('https://illumidesk.instructure.com/api/lti/authorize_redirect')}}"
+
+# shared drive
+shared_folder_enabled: "{{ shared_folder_enabled_param | default('true') }}"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -63,4 +63,4 @@ lti13_token_url: "{{ lti13_token_url_param | default('https://illumidesk.instruc
 lti13_authorize_url: "{{ lti13_authorize_url_param | default('https://illumidesk.instructure.com/api/lti/authorize_redirect')}}"
 
 # shared drive
-shared_folder_enabled: "{{ shared_folder_enabled_param | default('false') }}"
+shared_folder_enabled: "{{ shared_folder_enabled_param | default('true') }}"

--- a/ansible/hosts.example
+++ b/ansible/hosts.example
@@ -52,6 +52,9 @@ all:
       # /mnt/efs/fs1, to reduce the risk of overwriting content that may already exist in /mnt
       # mnt_root: /mnt/efs/fs1
 
+      # set to true to enable the shared drive option
+      shared_folder_enabled: true
+
       ### Genaral Options
       #-------------------
       # provide a string of that represents one admin user. Username should represent

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
@@ -136,7 +136,7 @@ notebook_dir = os.environ.get('DOCKER_NOTEBOOK_DIR')
 mnt_root = os.environ.get('MNT_ROOT')
 # Mount volumes
 c.DockerSpawner.volumes = {
-    f'{mnt_root}/{org_name}' + '/home/{raw_username}': notebook_dir,    
+    f'{mnt_root}/{org_name}' + '/home/{raw_username}': notebook_dir,
     f'{mnt_root}/{org_name}/exchange': exchange_dir,
 }
 shared_folder_enabled = os.environ.get('SHARED_FOLDER_ENABLED') or 'False'

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
@@ -137,6 +137,7 @@ mnt_root = os.environ.get('MNT_ROOT')
 # Mount volumes
 c.DockerSpawner.volumes = {
     f'{mnt_root}/{org_name}' + '/home/{raw_username}': notebook_dir,
+    f'{mnt_root}/{org_name}' + '/shared/': notebook_dir + '/shared',
     f'{mnt_root}/{org_name}/exchange': exchange_dir,
 }
 c.DockerSpawner.name_template = 'jupyter-{raw_username}'

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
@@ -136,10 +136,13 @@ notebook_dir = os.environ.get('DOCKER_NOTEBOOK_DIR')
 mnt_root = os.environ.get('MNT_ROOT')
 # Mount volumes
 c.DockerSpawner.volumes = {
-    f'{mnt_root}/{org_name}' + '/home/{raw_username}': notebook_dir,
-    f'{mnt_root}/{org_name}' + '/shared/': notebook_dir + '/shared',
+    f'{mnt_root}/{org_name}' + '/home/{raw_username}': notebook_dir,    
     f'{mnt_root}/{org_name}/exchange': exchange_dir,
 }
+shared_folder_enabled = os.environ.get('SHARED_FOLDER_ENABLED') or 'False'
+# add the shared folder if it was required
+if shared_folder_enabled.lower() in ('true', '1'):
+    c.DockerSpawner.volumes[f'{mnt_root}/{org_name}' + '/shared/'] = notebook_dir + '/shared'
 c.DockerSpawner.name_template = 'jupyter-{raw_username}'
 ##########################################
 # END CUSTOM DOCKERSPAWNER

--- a/ansible/roles/jupyterhub/templates/env.jhub.j2
+++ b/ansible/roles/jupyterhub/templates/env.jhub.j2
@@ -65,3 +65,5 @@ PROXY_API_URL=http://reverse-proxy:8099
 
 # anouncement service (internal)
 ANNOUNCEMENT_SERVICE_PORT=8889
+
+SHARED_FOLDER_ENABLED={{shared_folder_enabled}}

--- a/ansible/roles/setup_course/templates/env.setup_course.j2
+++ b/ansible/roles/setup_course/templates/env.setup_course.j2
@@ -26,3 +26,5 @@ MNT_ROOT={{mnt_root}}
 MNT_ROOT={{mnt_root}}
 NB_UID=10001
 NB_GID=100
+
+SHARED_FOLDER_ENABLED={{shared_folder_enabled}}

--- a/src/illumidesk/setup_course/course.py
+++ b/src/illumidesk/setup_course/course.py
@@ -112,11 +112,14 @@ class Course:
         logger.debug('Creating exchange directory %s' % self.exchange_root)
         self.exchange_root.mkdir(parents=True, exist_ok=True)
         self.exchange_root.chmod(0o777)
-        self.course_root.mkdir(parents=True, exist_ok=True)
+        logger.debug('Creating shared directory %s' % self.grader_shared_folder)
+        self.grader_shared_folder.mkdir(parents=True, exist_ok=True)
+        shutil.chown(str(self.grader_shared_folder), user=self.uid, group=self.gid)
         logger.debug(
             'Creating grader directory and permissions with path %s to %s:%s ' % (self.grader_root, self.uid, self.gid)
         )
         shutil.chown(str(self.grader_root), user=self.uid, group=self.gid)
+        self.course_root.mkdir(parents=True, exist_ok=True)
         logger.debug(
             'Changing course directory permissions with path %s to %s:%s ' % (self.course_root, self.uid, self.gid)
         )
@@ -203,6 +206,7 @@ class Course:
             volumes={
                 str(self.grader_root): {'bind': f'/home/{self.grader_name}'},
                 str(self.exchange_root): {'bind': '/srv/nbgrader/exchange'},
+                str(self.grader_shared_folder): {'bind': f'/home/{self.grader_name}/shared'},
             },
             name=self.grader_name,
             user='root',

--- a/src/illumidesk/setup_course/course.py
+++ b/src/illumidesk/setup_course/course.py
@@ -44,6 +44,7 @@ class Course:
         self.exchange_root = Path(os.environ.get('MNT_ROOT'), self.org, 'exchange')
         self.grader_name = f'grader-{course_id}'
         self.grader_root = Path(os.environ.get('MNT_ROOT'), org, 'home', self.grader_name,)
+        self.grader_shared_folder = Path(os.environ.get('MNT_ROOT'), org, 'shared', self.course_id)
         self.course_root = self.grader_root / course_id
         self.token = token_hex(32)
         self.client = docker.from_env()

--- a/src/illumidesk/setup_course/course.py
+++ b/src/illumidesk/setup_course/course.py
@@ -45,6 +45,8 @@ class Course:
         self.grader_name = f'grader-{course_id}'
         self.grader_root = Path(os.environ.get('MNT_ROOT'), org, 'home', self.grader_name,)
         self.grader_shared_folder = Path(os.environ.get('MNT_ROOT'), org, 'shared', self.course_id)
+        shared_folder_env = os.environ.get('SHARED_FOLDER_ENABLED') or 'False'
+        self.is_shared_folder_enabled = True if shared_folder_env.lower() in ('true', '1') else False
         self.course_root = self.grader_root / course_id
         self.token = token_hex(32)
         self.client = docker.from_env()
@@ -187,6 +189,13 @@ class Course:
         base_url = os.environ.get('JUPYTERHUB_BASE_URL') or ''
         logger.debug('Grader container JUPYTERHUB_API_URL set to %s' % jupyterhub_api_url)
         logger.debug('Grader container JUPYTERHUB_API_TOKEN set to %s' % jupyterhub_api_token)
+        # set initial volumes dict 
+        docker_volumes = {
+            str(self.grader_root): {'bind': f'/home/{self.grader_name}'},
+            str(self.exchange_root): {'bind': '/srv/nbgrader/exchange'},
+        }
+        if self.is_shared_folder_enabled:
+            docker_volumes[str(self.grader_shared_folder)] = {'bind': f'/home/{self.grader_name}/shared'}
         self.client.containers.run(
             detach=True,
             image=os.environ.get('GRADER_SERVICE_IMAGE'),
@@ -203,11 +212,7 @@ class Course:
                 f'NB_GID={self.gid}',
                 f'NB_USER={self.grader_name}',
             ],
-            volumes={
-                str(self.grader_root): {'bind': f'/home/{self.grader_name}'},
-                str(self.exchange_root): {'bind': '/srv/nbgrader/exchange'},
-                str(self.grader_shared_folder): {'bind': f'/home/{self.grader_name}/shared'},
-            },
+            volumes=docker_volumes,
             name=self.grader_name,
             user='root',
             working_dir=f'/home/{self.grader_name}',

--- a/src/illumidesk/setup_course/course.py
+++ b/src/illumidesk/setup_course/course.py
@@ -114,9 +114,6 @@ class Course:
         logger.debug('Creating exchange directory %s' % self.exchange_root)
         self.exchange_root.mkdir(parents=True, exist_ok=True)
         self.exchange_root.chmod(0o777)
-        logger.debug('Creating shared directory %s' % self.grader_shared_folder)
-        self.grader_shared_folder.mkdir(parents=True, exist_ok=True)
-        shutil.chown(str(self.grader_shared_folder), user=self.uid, group=self.gid)
         logger.debug(
             'Creating grader directory and permissions with path %s to %s:%s ' % (self.grader_root, self.uid, self.gid)
         )
@@ -149,6 +146,10 @@ class Course:
             'Added shared grader course nbgrader config %s with permissions %s:%s'
             % (nbgrader_config, self.uid, self.gid)
         )
+        if self.is_shared_folder_enabled is True:
+            logger.debug('Creating shared directory %s' % self.grader_shared_folder)
+            self.grader_shared_folder.mkdir(parents=True, exist_ok=True)
+            shutil.chown(str(self.grader_shared_folder), user=self.uid, group=self.gid)
 
     async def add_jupyterhub_grader_group(self):
         """

--- a/src/illumidesk/spawners/spawners.py
+++ b/src/illumidesk/spawners/spawners.py
@@ -3,6 +3,7 @@ import os
 from dockerspawner import DockerSpawner
 
 from illumidesk.authenticators.utils import user_is_a_student
+from illumidesk.authenticators.utils import user_is_an_instructor
 
 from illumidesk.spawners.hooks import custom_auth_state_hook
 from illumidesk.spawners.hooks import custom_pre_spawn_hook
@@ -21,6 +22,20 @@ class IllumiDeskBaseDockerSpawner(DockerSpawner):
     def auth_state_hook(self, spawner: DockerSpawner, auth_state: dict) -> None:
         # call our custom hook from here without issue related with 'invalid arguments number given'
         custom_auth_state_hook(spawner, auth_state)
+
+    def _volumes_to_binds(self, volumes, binds, mode="rw"):
+        binds = super()._volumes_to_binds(volumes, binds, mode)
+        self.log.debug(f'binds loaded from volumes setting-> {binds}')
+        shared_vol_key = ''
+        for k, v in binds.items():
+            if '/shared' in v['bind']:
+                shared_vol_key = k
+                break
+        if shared_vol_key and user_is_an_instructor(self.environment['USER_ROLE']):
+            self.log.debug(f'Removing shared folder for instructor')    
+            del binds[shared_vol_key]
+        self.log.debug(f'binds without the shared folder: {binds}')
+        return binds
 
     def pre_spawn_hook(self, spawner) -> None:
         custom_pre_spawn_hook(spawner)

--- a/src/illumidesk/spawners/spawners.py
+++ b/src/illumidesk/spawners/spawners.py
@@ -8,11 +8,18 @@ from illumidesk.authenticators.utils import user_is_an_instructor
 from illumidesk.spawners.hooks import custom_auth_state_hook
 from illumidesk.spawners.hooks import custom_pre_spawn_hook
 
+from traitlets.traitlets import Bool
+
 
 class IllumiDeskBaseDockerSpawner(DockerSpawner):
     """
     Extends the DockerSpawner by defining the common behavior for our Spwaners that work with LTI versions 1.1 and 1.3
     """
+    load_shared_folder_with_instructor = Bool(
+        True,
+        config=True,
+        help="Mount the shared folder with Instructor role (Used with shared_folder_enabled env-var).",
+    )
 
     def _get_image_name(self) -> str:
         raise NotImplementedError(
@@ -25,16 +32,17 @@ class IllumiDeskBaseDockerSpawner(DockerSpawner):
 
     def _volumes_to_binds(self, volumes, binds, mode="rw"):
         binds = super()._volumes_to_binds(volumes, binds, mode)
-        self.log.debug(f'binds loaded from volumes setting-> {binds}')
-        shared_vol_key = ''
-        for k, v in binds.items():
-            if '/shared' in v['bind']:
-                shared_vol_key = k
-                break
-        if shared_vol_key and user_is_an_instructor(self.environment['USER_ROLE']):
-            self.log.debug(f'Removing shared folder for instructor')    
-            del binds[shared_vol_key]
-        self.log.debug(f'binds without the shared folder: {binds}')
+        if self.load_shared_folder_with_instructor is False and user_is_an_instructor(self.environment['USER_ROLE']):
+            self.log.debug(f'binds loaded from volumes setting: {binds}')
+            shared_vol_key = ''
+            for k, v in binds.items():
+                if '/shared' in v['bind']:
+                    shared_vol_key = k
+                    break
+            if shared_vol_key:
+                self.log.debug(f'Removing shared folder for instructor')    
+                del binds[shared_vol_key]
+                self.log.debug(f'binds without the shared folder: {binds}')
         return binds
 
     def pre_spawn_hook(self, spawner) -> None:

--- a/src/setup.py
+++ b/src/setup.py
@@ -42,7 +42,7 @@ setup(
         'jupyterhub>=1.1.0',
         'jupyterhub-ltiauthenticator>=0.4.0',
         'jwcrypto==0.7',
-        'nbgrader@git+https://github.com/IllumiDesk/nbgrader#egg=nbgrader-0.6.2',
+        'nbgrader@git+https://github.com/IllumiDesk/nbgrader#egg=nbgrader-0.6.3',
         'oauthenticator==0.11.0',
         'pem==20.1.0',
         'PyJWT==1.7.1',

--- a/src/tests/illumidesk/setup_course/test_course.py
+++ b/src/tests/illumidesk/setup_course/test_course.py
@@ -142,6 +142,30 @@ def test_course_root_directory_is_created(setup_course_environ):
         assert course.course_root.exists()
 
 
+def test_course_shared_folder_is_not_created_if_env_var_was_not_set(setup_course_environ, monkeypatch):
+    """
+    Is the course directory created as part of setup?
+    """
+    monkeypatch.setenv('SHARED_FOLDER_ENABLED', '')
+    course = Course(org='org1', course_id='example', domain='example.com')
+    with patch('shutil.chown', autospec=True):
+        course.create_directories()
+        assert course.is_shared_folder_enabled is False
+        assert not course.grader_shared_folder.exists()
+
+
+def test_course_shared_folder_is_created_if_env_var_was_set(setup_course_environ, monkeypatch):
+    """
+    Is the course directory created as part of setup?
+    """
+    monkeypatch.setenv('SHARED_FOLDER_ENABLED', 'True')
+    course = Course(org='org1', course_id='example', domain='example.com')
+    with patch('shutil.chown', autospec=True):
+        course.create_directories()
+        assert course.is_shared_folder_enabled is True
+        assert course.grader_shared_folder.exists()
+
+
 def test_course_jupyter_config_path_is_created(setup_course_environ):
     """
     Is the jupyter config directory created as part of setup?

--- a/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
+++ b/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
@@ -3,8 +3,38 @@ import pytest
 import types
 
 from dockerspawner.dockerspawner import DockerSpawner
+from illumidesk.authenticators.authenticator import setup_course_hook
 
+from illumidesk.spawners.spawners import IllumiDeskBaseDockerSpawner
 from illumidesk.spawners.spawners import IllumiDeskRoleDockerSpawner
+
+
+def test_base_spawner_does_not_consider_shared_folder_with_instructor_role(setup_image_environ, mock_jhub_user):
+    """
+    Does the IllumiDeskBaseDockerSpawner class exclude the shared folder for instructors?
+    """
+    sut = IllumiDeskBaseDockerSpawner()
+    sut.environment['USER_ROLE'] = 'Instructor'
+    sut.user = mock_jhub_user()
+    volumes_to_mount = {
+        f'mnt_root/my-org/shared/': 'home/jovyan/shared'
+    }
+    binds = sut._volumes_to_binds(volumes=volumes_to_mount, binds={})
+    assert len(binds) == 0
+
+
+def test_base_spawner_returns_the_shared_folder_with_learner_role(setup_image_environ, mock_jhub_user):
+    """
+    Does the IllumiDeskBaseDockerSpawner class consider the shared folder for learners?
+    """
+    sut = IllumiDeskBaseDockerSpawner()
+    sut.environment['USER_ROLE'] = 'Learner'
+    sut.user = mock_jhub_user()
+    volumes_to_mount = {
+        f'mnt_root/my-org/shared/': 'home/jovyan/shared'
+    }
+    binds = sut._volumes_to_binds(volumes=volumes_to_mount, binds={})
+    assert len(binds) == 1
 
 
 def test_get_image_name_returns_correct_image_for_student_role(setup_image_environ, mock_jhub_user):

--- a/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
+++ b/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
@@ -9,11 +9,11 @@ from illumidesk.spawners.spawners import IllumiDeskBaseDockerSpawner
 from illumidesk.spawners.spawners import IllumiDeskRoleDockerSpawner
 
 
-def test_base_spawner_does_not_consider_shared_folder_with_instructor_role(setup_image_environ, mock_jhub_user):
+def test_base_spawner_does_not_consider_shared_folder_with_instructor_role_when_jhub_setting_is_False(setup_image_environ, mock_jhub_user):
     """
-    Does the IllumiDeskBaseDockerSpawner class exclude the shared folder for instructors?
+    Does the IllumiDeskBaseDockerSpawner class exclude the shared folder for instructors when load_shared_folder_with_instructor is False?
     """
-    sut = IllumiDeskBaseDockerSpawner()
+    sut = IllumiDeskBaseDockerSpawner(load_shared_folder_with_instructor=False)
     sut.environment['USER_ROLE'] = 'Instructor'
     sut.user = mock_jhub_user()
     volumes_to_mount = {
@@ -23,7 +23,21 @@ def test_base_spawner_does_not_consider_shared_folder_with_instructor_role(setup
     assert len(binds) == 0
 
 
-def test_base_spawner_returns_the_shared_folder_with_learner_role(setup_image_environ, mock_jhub_user):
+def test_base_spawner_load_shared_folder_with_instructor_role_when_jhub_setting_is_True(setup_image_environ, mock_jhub_user):
+    """
+    Does the IllumiDeskBaseDockerSpawner class load the shared folder for instructors?
+    """
+    sut = IllumiDeskBaseDockerSpawner(load_shared_folder_with_instructor=True)
+    sut.environment['USER_ROLE'] = 'Instructor'
+    sut.user = mock_jhub_user()
+    volumes_to_mount = {
+        f'mnt_root/my-org/shared/': 'home/jovyan/shared'
+    }
+    binds = sut._volumes_to_binds(volumes=volumes_to_mount, binds={})
+    assert len(binds) == 1
+
+
+def test_base_spawner_returns_the_shared_folder_with_learner_role_not_matter_the_jhub_setting(setup_image_environ, mock_jhub_user):
     """
     Does the IllumiDeskBaseDockerSpawner class consider the shared folder for learners?
     """
@@ -34,6 +48,14 @@ def test_base_spawner_returns_the_shared_folder_with_learner_role(setup_image_en
         f'mnt_root/my-org/shared/': 'home/jovyan/shared'
     }
     binds = sut._volumes_to_binds(volumes=volumes_to_mount, binds={})
+    # First case (setting is not used)
+    assert len(binds) == 1
+    sut.load_shared_folder_with_instructor = False
+    volumes_to_mount = {
+        f'mnt_root/my-org/shared/': 'home/jovyan/shared'
+    }
+    binds = sut._volumes_to_binds(volumes=volumes_to_mount, binds={})
+    # First case (setting is used)
     assert len(binds) == 1
 
 


### PR DESCRIPTION
Whit this first approach the setup-course service is creating the "course shared folder" in the path `/<mnt_root>/<org_name>/shared/<course-id>` (with the permissions 10001:100) for the **grader notebooks**.

For the **notebooks case** there is a new volume item in the jupyterhub settings (that applied to all notebooks) that allows to mount the `/<mnt_root>/<org_name>/shared`  in `/home/jovyan/shared`. Notice the host folder termination (/shared ) with this all the future courses will reflected automatically 

Closes #245 


Some screens:

**grader notebook**
<img width="1405" alt="shared-drive-grader" src="https://user-images.githubusercontent.com/2465401/90304798-e5c08100-de80-11ea-8cec-97a19c665d22.png">

**normal notebook**
<img width="1430" alt="shared-drive-learner" src="https://user-images.githubusercontent.com/2465401/90304816-199ba680-de81-11ea-9ed1-6fb42306eb60.png">

