### PR TITLE
Update default JupyterHub configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 # IllumiDesk
 
+:warning: Thanks to the amazing feedback we have gotten from the community, the IllumiDesk Team is currently re implementing many of the components listed in this document. For the most part these changes are and will be backwards compatible, however, please proceed with caution if you plan on using this setup in a production environment (not recommended) :warning:
+
 ## Overview
 
 [Jupyter Notebooks](https://jupyter.org) are a great **education tool** for a variety of subjects since it offers instructors and learners a unified document standard to combine markdown, code, and rich visualizations. With the proper setup, Jupyter Notebooks allow organizations to enhance their learning experiences.
@@ -283,6 +285,8 @@ When building the images the configuration files are copied to the image from th
 ### Spawners
 
 By default this setup includes the `IllumiDeskRoleDockerSpawner` class. However, you should be able to use any container based spawner. This implementation utilizes the `auth_state_hook` to get the user's authentication dictionary, and based on the spawner class sets the docker image to spawn based on the `user_role` key with the spawner's `auth_state_hook`. The `pre_spawn_hook` to add user directories with the appropriate permissions, since users are not added to the operating system.
+
+**Note**: the user is redirected to their server by default with `JupyterHub.redirect_to_server = True`.
 
 #### IllumiDeskRoleDockerSpawner
 

--- a/README.md
+++ b/README.md
@@ -158,20 +158,22 @@ With shared_folder_enabled set to true, users with access to the shared grader s
 
 Additional workspace types are supported by any workspace type that is supported by the underlying [jupyter-server-proxy] package. This stack has been tested with a variety of workspace types including:
 
-IDEs
+#### IDEs
 
-Theia
-RStudio
-VS Code
-Data Tools
+- Theia
+- RStudio
+- VS Code (code-server)
 
-OpenRefine
-Visualization/Dashboard Servers
+#### Data Tools
 
-Plotly Dash
-Streamlit
-Bokeh Server
-Jupyter Voila
+- OpenRefine
+
+#### Visualization/Dashboard Servers
+
+- Plotly Dash
+- Streamlit
+- Bokeh Server
+- Jupyter Voila
 
 When you want to use a specific workspace type simply leverage the existing [user redirect](https://jupyterhub.readthedocs.io/en/stable/reference/urls.html#user-redirect) functionality available with JupyterHub combined with the query parameter next. For example, with LTI 1.1 the launch url would look like so:
 
@@ -319,8 +321,8 @@ This setup uses JupyterHub's [configurable-http-proxy]((https://github.com/jupyt
 
 **Requirements**
 
-- The Jupyter Notebook image needs to have `JupyterHub` installed and this version of JupyterHub **must coincide with the version of JupyterHub that is spawing the Jupyter Notebook**. By default the `jupyter/docker-stacks` images have JupyterHub installed.
-- Use one of images provided by the [`jupyter/docker-stacks`](https://github.com/jupyter/docker-stacks) images as the base image.
+- The Jupyter Notebook image needs to have `JupyterHub` installed and this version of JupyterHub **must coincide with the version of JupyterHub that is spawing the Jupyter Notebook**. By default the `illumidesk/docker-stacks` images have JupyterHub installed.
+- Use one of images provided by the [`jupyter/docker-stacks`](https://github.com/jupyter/docker-stacks).
 - Make sure the image is on the host used by the spawner to launch the user's Jupyter Notebook.
 
 There are three notebook images:
@@ -462,6 +464,7 @@ The services included with this setup rely on environment variables to work prop
 | POSTGRES_PASSWORD | `string` | Postgres database password | `jupyterhub` |
 | POSTGRES_HOST | `string` | Postgres host | `jupyterhub-db` |
 | SHARED_FOLDER_ENABLED | `string` | Specifies the use of shared folder (between grader and student notebooks)  | `True` |
+| SPAWNER_MEM_LIMIT | `string` | Spawner memory limit | `2G` |
 
 ### Environment Variables pertaining to setup-course service, located in `env.setup-course`
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -64,3 +64,6 @@ lti13_authorize_url: "{{ lti13_authorize_url_param | default('https://illumidesk
 
 # shared drive
 shared_folder_enabled: "{{ shared_folder_enabled_param | default('true') }}"
+
+# spawner
+spawner_mem_limit: "{{ spawner_mem_limit_param | default('2G') }}"

--- a/ansible/hosts.example
+++ b/ansible/hosts.example
@@ -97,3 +97,7 @@ all:
       # lti13_endpoint: https://illumidesk.instructure.com/api/lti/security/jwks
       # lti13_token_url: https://illumidesk.instructure.com/login/oauth2/token
       # lti13_authorize_url: https://illumidesk.instructure.com/api/lti/authorize_redirect
+
+      ## Spawner
+      # uncomment and add your preferred memory limit settings for user workspaces
+      # spawner_mem_limit: 2G

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
@@ -135,7 +135,7 @@ c.Authenticator.enable_auth_state = True
 ##########################################
 
 # Limit memory
-c.Spawner.mem_limit = '1G'
+c.Spawner.mem_limit = '2G'
 
 ##########################################
 # END GENERAL SPAWNER

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
@@ -10,31 +10,44 @@ c = get_config()
 ##########################################
 # BEGIN JUPYTERHUB APPLICATION
 ##########################################
+
 # Set to debug for testing
 c.JupyterHub.log_level = 'DEBUG'
+
 # Allows multiple single-server per user
 c.JupyterHub.allow_named_servers = False
+
 # Load data files
 c.JupyterHub.data_files_path = '/usr/local/share/jupyterhub/'
+
 # Use custom logo
 c.JupyterHub.logo_file = os.path.join('/usr/local/share/jupyterhub/', 'static', 'images', 'illumidesk-80.png')
+
 # Template files
 c.JupyterHub.template_paths = ('/usr/local/share/jupyterhub/templates',)
+
 # Allow the hub to listen on any ip address
 c.JupyterHub.hub_ip = '0.0.0.0'
+
 # This is usually the hub container's name
 c.JupyterHub.hub_connect_ip = 'jupyterhub'
+
 # Provide iframe support
 c.JupyterHub.tornado_settings = {"headers": {"Content-Security-Policy": "frame-ancestors 'self' *"}}
+
 # Load data files
 c.JupyterHub.data_files_path = '/usr/local/share/jupyterhub/'
+
 # Persist hub cookie secret on volume mounted inside container
 data_dir = '/data'
 c.JupyterHub.cookie_secret_file = os.path.join(data_dir, 'jupyterhub_cookie_secret')
+
 # Allow admin access to end-user notebooks
 c.JupyterHub.admin_access = True
+
 # Refrain from cleaning up servers when restarting the hub
 c.JupyterHub.cleanup_servers = False
+
 # Define some static services that jupyterhub will manage
 # Although the cull-idle service is internal, and therefore does not need an explicit
 # registration of the jupyterhub api token, we add it here so the internal api client
@@ -56,12 +69,17 @@ c.JupyterHub.db_url = 'postgresql://{user}:{password}@{host}/{db}'.format(
     host=os.environ.get('POSTGRES_HOST'),
     db=os.environ.get('POSTGRES_DB'),
 )
+
 # Do not redirect user to his/her server (if running)
 c.JupyterHub.redirect_to_server = False
 
 # JupyterHub's base url
 base_url = os.environ.get('JUPYTERHUB_BASE_URL') or ''
 c.JupyterHub.base_url = base_url
+
+# Do not redirect user to his/her server (if running)
+c.JupyterHub.redirect_to_server = True
+
 ##########################################
 # END JUPYTERHUB APPLICATION
 ##########################################
@@ -74,16 +92,22 @@ from jupyterhub_traefik_proxy import TraefikTomlProxy
 
 # configure JupyterHub to use TraefikTomlProxy
 c.JupyterHub.proxy_class = TraefikTomlProxy
+
 # mark the proxy as externally managed
 c.TraefikTomlProxy.should_start = False
+
 # indicate the proxy url to allow register new routes
 c.TraefikProxy.traefik_api_url = os.environ.get('PROXY_API_URL') or 'http://reverse-proxy:8099'
+
 # traefik api endpoint login password
 c.TraefikTomlProxy.traefik_api_password = "admin"
+
 # traefik api endpoint login username
 c.TraefikTomlProxy.traefik_api_username = "api_admin"
+
 # traefik's dynamic configuration file
 c.TraefikTomlProxy.toml_dynamic_config_file = "/etc/traefik/rules.toml"
+
 ##########################################
 # END REVERSE PROXY
 ##########################################
@@ -91,14 +115,17 @@ c.TraefikTomlProxy.toml_dynamic_config_file = "/etc/traefik/rules.toml"
 ##########################################
 # BEGIN GENERAL AUTHENTICATION
 ##########################################
+
 admin_user = os.environ.get('JUPYTERHUB_ADMIN_USER')
 # Add other admin users as needed
 c.Authenticator.admin_users = {
     admin_user,
 }
+
 # If using an authenticator which requires additional logic,
 # set to True.
 c.Authenticator.enable_auth_state = True
+
 ##########################################
 # END GENERAL AUTHENTICATION
 ##########################################
@@ -106,8 +133,10 @@ c.Authenticator.enable_auth_state = True
 ##########################################
 # BEGIN GENERAL SPAWNER
 ##########################################
+
 # Limit memory
 c.Spawner.mem_limit = '1G'
+
 ##########################################
 # END GENERAL SPAWNER
 ##########################################
@@ -115,31 +144,41 @@ c.Spawner.mem_limit = '1G'
 ##########################################
 # BEGIN CUSTOM DOCKERSPAWNER
 ##########################################
+
 # Allow container to use any ip address
 c.DockerSpawner.host_ip = '0.0.0.0'
+
 # specify the command used by the spawner to start every container
 spawn_cmd = os.environ.get('DOCKER_SPAWN_CMD') or 'start-singleuser.sh'
 c.DockerSpawner.extra_create_kwargs.update({'command': spawn_cmd})
+
 # Tell the user containers to connect to our docker network
 network_name = os.environ.get('DOCKER_NETWORK_NAME') or 'jupyter-network'
 c.DockerSpawner.network_name = network_name
+
 # Remove containers when stopping the hub
 c.DockerSpawner.remove_containers = True
 c.DockerSpawner.remove = True
+
 # nbgrader exchange directory
 exchange_dir = os.environ.get('EXCHANGE_DIR') or '/srv/nbgrader/exchange'
+
 # Organization name
 org_name = os.environ.get('ORGANIZATION_NAME') or 'my-org'
+
 # Notebook directory within docker image
 notebook_dir = os.environ.get('DOCKER_NOTEBOOK_DIR')
+
 # Root directory to mount org, home, and exchange folders
 mnt_root = os.environ.get('MNT_ROOT')
+
 # Mount volumes
 c.DockerSpawner.volumes = {
     f'{mnt_root}/{org_name}' + '/home/{raw_username}': notebook_dir,
     f'{mnt_root}/{org_name}/exchange': exchange_dir,
 }
 shared_folder_enabled = os.environ.get('SHARED_FOLDER_ENABLED') or 'False'
+
 # add the shared folder if it was required
 if shared_folder_enabled.lower() in ('true', '1'):
     c.DockerSpawner.volumes[f'{mnt_root}/{org_name}' + '/shared/'] = notebook_dir + '/shared'

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
@@ -11,7 +11,7 @@ c = get_config()
 # BEGIN JUPYTERHUB APPLICATION
 ##########################################
 
-# Set to debug for testing
+# Set to debug for teting
 c.JupyterHub.log_level = 'DEBUG'
 
 # Allows multiple single-server per user
@@ -100,13 +100,13 @@ c.TraefikTomlProxy.should_start = False
 c.TraefikProxy.traefik_api_url = os.environ.get('PROXY_API_URL') or 'http://reverse-proxy:8099'
 
 # traefik api endpoint login password
-c.TraefikTomlProxy.traefik_api_password = "admin"
+c.TraefikTomlProxy.traefik_api_password = 'admin'
 
 # traefik api endpoint login username
-c.TraefikTomlProxy.traefik_api_username = "api_admin"
+c.TraefikTomlProxy.traefik_api_username = 'api_admin'
 
 # traefik's dynamic configuration file
-c.TraefikTomlProxy.toml_dynamic_config_file = "/etc/traefik/rules.toml"
+c.TraefikTomlProxy.toml_dynamic_config_file = '/etc/traefik/rules.toml'
 
 ##########################################
 # END REVERSE PROXY
@@ -177,9 +177,9 @@ c.DockerSpawner.volumes = {
     f'{mnt_root}/{org_name}' + '/home/{raw_username}': notebook_dir,
     f'{mnt_root}/{org_name}/exchange': exchange_dir,
 }
-shared_folder_enabled = os.environ.get('SHARED_FOLDER_ENABLED') or 'False'
 
 # add the shared folder if it was required
+shared_folder_enabled = os.environ.get('SHARED_FOLDER_ENABLED') or 'False'
 if shared_folder_enabled.lower() in ('true', '1'):
     c.DockerSpawner.volumes[f'{mnt_root}/{org_name}' + '/shared/'] = notebook_dir + '/shared'
 c.DockerSpawner.name_template = 'jupyter-{raw_username}'

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
@@ -135,7 +135,7 @@ c.Authenticator.enable_auth_state = True
 ##########################################
 
 # Limit memory
-c.Spawner.mem_limit = '2G'
+c.Spawner.mem_limit = os.environ.get('DOCKER_SPAWN_MEM_LIMIT') or '2G'
 
 ##########################################
 # END GENERAL SPAWNER

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
@@ -1,7 +1,4 @@
 import os
-import sys
-
-import requests
 
 from illumidesk.apis.setup_course_service import get_current_service_definitions
 from illumidesk.authenticators.authenticator import LTI11Authenticator
@@ -12,17 +9,19 @@ from illumidesk.spawners.spawners import IllumiDeskRoleDockerSpawner
 
 c = get_config()
 
-# FIRST load the base configuration file (with common settings)
-load_subconfig('/etc/jupyterhub/jupyterhub_config_base.py')
-# THEN override the settings that apply only with LT13 authentication type
+# load the base configuration file (with common settings)
+load_subconfig('/etc/jupyterhub/jupyterhub_config_base.py')  # noqa: F821
 
 ##########################################
 # BEGIN JUPYTERHUB APPLICATION
 ##########################################
+
 # LTI 1.1 authenticator class.
 c.JupyterHub.authenticator_class = LTI11Authenticator
+
 # Spawn containers with by role
 c.JupyterHub.spawner_class = IllumiDeskRoleDockerSpawner
+
 ##########################################
 # END JUPYTERHUB APPLICATION
 ##########################################
@@ -35,12 +34,14 @@ c.LTIAuthenticator.consumers = {
     or 'ild_test_consumer_key': os.environ.get('LTI_SHARED_SECRET')
     or 'ild_test_shared_secret'
 }
+
 # Custom Handlers
 # the first one is used to send grades to LMS
 # this url pattern was changed to accept spaces in the assignment name
 c.JupyterHub.extra_handlers = [
     (r'/submit-grades/(?P<course_id>[a-zA-Z0-9-_]+)/(?P<assignment_name>.*)$', SendGradesHandler,),
 ]
+
 ##########################################
 # END LTI 1.1 AUTHENTICATOR
 ##########################################
@@ -48,8 +49,10 @@ c.JupyterHub.extra_handlers = [
 ##########################################
 # BEGIN GENERAL AUTHENTICATION
 ##########################################
+
 # Post auth hook to setup course
 c.Authenticator.post_auth_hook = setup_course_hook
+
 ##########################################
 # END GENERAL AUTHENTICATION
 ##########################################
@@ -57,11 +60,14 @@ c.Authenticator.post_auth_hook = setup_course_hook
 ##########################################
 # SETUP COURSE SERVICE
 ##########################################
+
 # Dynamic config to setup new courses
 extra_services = get_current_service_definitions()
+
 # load k/v's when starting jupyterhub
 c.JupyterHub.load_groups.update(extra_services['load_groups'])
 c.JupyterHub.services.extend(extra_services['services'])
+
 ##########################################
 # END SETUP COURSE SERVICE
 ##########################################

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti13.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti13.py
@@ -14,18 +14,20 @@ from illumidesk.spawners.spawners import IllumiDeskRoleDockerSpawner
 
 c = get_config()
 
-# FIRST load the base configuration file (with common settings)
-load_subconfig('/etc/jupyterhub/jupyterhub_config_base.py')
 
-# THEN override the settings that apply only with LT13 authentication type
+# load the base configuration file (with common settings)
+load_subconfig('/etc/jupyterhub/jupyterhub_config_base.py')  # noqa: F821
 
 ##########################################
 # BEGIN LTI 1.3 AUTHENTICATOR
 ##########################################
+
 # LTI 1.3 authenticator class.
 c.JupyterHub.authenticator_class = LTI13Authenticator
+
 # Spawn containers with by role
 c.JupyterHub.spawner_class = IllumiDeskRoleDockerSpawner
+
 # created after installing app in lms
 c.LTI13Authenticator.client_id = os.environ.get('LTI13_CLIENT_ID')
 c.LTI13Authenticator.endpoint = os.environ.get('LTI13_ENDPOINT')
@@ -41,6 +43,7 @@ c.JupyterHub.extra_handlers = [
     (r'/lti13/config$', LTI13ConfigHandler),
     (r'/lti13/jwks$', LTI13JWKSHandler),
 ]
+
 ##########################################
 # END LTI 1.3 AUTHENTICATOR
 ##########################################
@@ -51,6 +54,7 @@ c.JupyterHub.extra_handlers = [
 
 # Post auth hook to setup course
 c.Authenticator.post_auth_hook = setup_course_hook
+
 ##########################################
 # END GENERAL AUTHENTICATION
 ##########################################
@@ -58,11 +62,14 @@ c.Authenticator.post_auth_hook = setup_course_hook
 ##########################################
 # SETUP COURSE SERVICE
 ##########################################
+
 # Dynamic config to setup new courses
 extra_services = get_current_service_definitions()
+
 # load k/v's when starting jupyterhub
 c.JupyterHub.load_groups.update(extra_services['load_groups'])
 c.JupyterHub.services.extend(extra_services['services'])
+
 ##########################################
 # END SETUP COURSE SERVICE
 ##########################################

--- a/ansible/roles/jupyterhub/templates/env.jhub.j2
+++ b/ansible/roles/jupyterhub/templates/env.jhub.j2
@@ -66,3 +66,5 @@ PROXY_API_URL=http://reverse-proxy:8099
 ANNOUNCEMENT_SERVICE_PORT=8889
 
 SHARED_FOLDER_ENABLED={{shared_folder_enabled}}
+
+SPAWNER_MEM_LIMIT={{spawner_mem_limit}}


### PR DESCRIPTION
- Updates config to redirect users to their servers (JupyterHub.redirect_to_server = True)
- Updates default memory to 2 gigs (Spawner.mem_limit = '2G')
- Adds environment variable to set spawner memory options

