### PR TITLE
Make sure the course directory exists

### DIFF
--- a/src/illumidesk/grades/sender_controlfile.py
+++ b/src/illumidesk/grades/sender_controlfile.py
@@ -29,6 +29,8 @@ class LTIGradesSenderControlFile:
         if not LTIGradesSenderControlFile.FILE_LOADED:
             logger.debug('The control file cache will be loaded from filesystem...')
             # try to read first time
+            # make sure the path exists
+            Path(self.config_path).mkdir(parents=True, exist_ok=True)
             self._loadFromFile()
 
     @property

--- a/src/tests/illumidesk/authenticators/test_lti11_authenticator.py
+++ b/src/tests/illumidesk/authenticators/test_lti11_authenticator.py
@@ -20,7 +20,8 @@ def gradesender_controlfile_mock():
         _loadFromFile=Mock(),
         register_data=Mock(return_value=None),
     ) as mock_controlfile:
-        yield mock_controlfile
+        with patch('pathlib.Path.mkdir'):
+            yield mock_controlfile
 
 
 @pytest.mark.asyncio
@@ -124,8 +125,9 @@ async def test_authenticator_uses_lti_utils_normalize_string(
 
 
 @pytest.mark.asyncio
+@patch('pathlib.Path.mkdir')
 async def test_authenticator_uses_lti_grades_sender_control_file_with_student_role(
-    tmp_path, make_lti11_success_authentication_request_args, mock_nbhelper
+    mock_mkdir, tmp_path, make_lti11_success_authentication_request_args, mock_nbhelper
 ):
     """
     Is the LTIGradesSenderControlFile class register_data method called when setting the user_role with the
@@ -157,8 +159,9 @@ async def test_authenticator_uses_lti_grades_sender_control_file_with_student_ro
 
 
 @pytest.mark.asyncio
+@patch('pathlib.Path.mkdir')
 async def test_authenticator_uses_lti_grades_sender_control_file_with_learner_role(
-    tmp_path, make_lti11_success_authentication_request_args, mock_nbhelper
+    mock_mkdir, tmp_path, make_lti11_success_authentication_request_args, mock_nbhelper
 ):
     """
     Is the LTIGradesSenderControlFile class register_data method called when setting the user_role with the
@@ -190,8 +193,9 @@ async def test_authenticator_uses_lti_grades_sender_control_file_with_learner_ro
 
 
 @pytest.mark.asyncio
+@patch('pathlib.Path.mkdir')
 async def test_authenticator_uses_lti_grades_sender_control_file_with_instructor_role(
-    tmp_path, make_lti11_success_authentication_request_args, mock_nbhelper
+    mock_mkdir, tmp_path, make_lti11_success_authentication_request_args, mock_nbhelper
 ):
     """
     Is the LTIGradesSenderControlFile class register_data method called when setting the user_role with the

--- a/src/tests/illumidesk/grades/test_sender_controlfile.py
+++ b/src/tests/illumidesk/grades/test_sender_controlfile.py
@@ -1,3 +1,4 @@
+import os
 import json
 import pytest
 
@@ -15,6 +16,17 @@ class TestLTIGradesSenderControlFile:
         Does the LTIGradesSenderControlFile class initializes a file with an empty dict when it does not exist?
         """
         sender_controlfile = LTIGradesSenderControlFile(tmp_path)
+        assert Path(sender_controlfile.config_fullname).stat().st_size > 0
+        with Path(sender_controlfile.config_fullname).open('r') as file:
+            assert json.load(file) == {}
+
+    def test_control_file_course_dir_is_created_if_not_exists(self, tmp_path):
+        """
+        Does the LTIGradesSenderControlFile class initializes a file with an empty dict when it does not exist?
+        """
+        course_dir = os.path.join(tmp_path, 'my-course')
+        sender_controlfile = LTIGradesSenderControlFile(course_dir)
+        assert Path(course_dir).exists()
         assert Path(sender_controlfile.config_fullname).stat().st_size > 0
         with Path(sender_controlfile.config_fullname).open('r') as file:
             assert json.load(file) == {}


### PR DESCRIPTION
For LTI11 when creating the json control file the code assumed the course directory existed but the grader service has not started yet