### PR TITLE
Remove image by role

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Click on the `Grader Console` tab and follow the steps available within the nbgr
 
 * **Authenticator**: The JupyterHub compatible authentication service. We recommend either using the `LTI11Authenticator` or `LTI13Authenticator` with your Learning Management System to take advantage of the latest features.
 
-* **Spawner**: Spawning service to manage user notebooks. This setup uses one class which inherits from the [DockerSpawner](https://github.com/jupyterhub/dockerspawner) class: the `IllumiDeskRoleDockerSpawner` to set the user's docker image based on LTI role.
+* **Spawner**: Spawning service to manage user notebooks. This setup uses one class which inherits from the [DockerSpawner](https://github.com/jupyterhub/dockerspawner) class: the `IllumiDeskDockerSpawner` to set the user's docker image based on LTI role.
 
 * **Data Directories**: This repo uses `docker-compose` to start all services and data volumes for JupyterHub, notebook directories, databases, and the `nbgrader exchange` directory using mounts from the host's file system.
 
@@ -286,29 +286,29 @@ When building the images the configuration files are copied to the image from th
 
 ### Spawners
 
-By default this setup includes the `IllumiDeskRoleDockerSpawner` class. However, you should be able to use any container based spawner. This implementation utilizes the `auth_state_hook` to get the user's authentication dictionary, and based on the spawner class sets the docker image to spawn based on the `user_role` key with the spawner's `auth_state_hook`. The `pre_spawn_hook` to add user directories with the appropriate permissions, since users are not added to the operating system.
+By default this setup includes the `IllumiDeskDockerSpawner` class. However, you should be able to use any container based spawner. This implementation utilizes the `auth_state_hook` to get the user's authentication dictionary, and based on the spawner class sets the docker image to spawn based on the `user_role` key with the spawner's `auth_state_hook`. The `pre_spawn_hook` to add user directories with the appropriate permissions, since users are not added to the operating system.
 
 **Note**: the user is redirected to their server by default with `JupyterHub.redirect_to_server = True`.
 
-#### IllumiDeskRoleDockerSpawner
+#### IllumiDeskDockerSpawner
 
-The `IllumiDeskRoleDockerSpawner` interprets LTI-based roles to determine which container to launch based on the user's role. If used with `nbgrader`, this class provides users with a container prepared for students to fetch and submit assignment and instructors with access the shared grader service for each course.
+The `IllumiDeskDockerSpawner` interprets LTI-based roles to determine which container to launch based on the user's role. If used with `nbgrader`, this class provides users with a container prepared for students to fetch and submit assignment and instructors with access the shared grader service for each course.
 
 Edit the `JupyterHub.spawner_class` to update the spawner used by JupyterHub when launching user containers. For example, if you are changing the spawner from `DockerSpawner` to `KubeSpawner`:
 
 Before:
 
 ```python
-c.JupyterHub.spawner_class = 'dockerspawner.IllumiDeskRoleDockerSpawner'
+c.JupyterHub.spawner_class = 'dockerspawner.IllumiDeskDockerSpawner'
 ```
 
 After:
 
 ```python
-c.JupyterHub.spawner_class = 'kubespawner.IllumiDeskRoleDockerSpawner'
+c.JupyterHub.spawner_class = 'kubespawner.KubeSpawner'
 ```
 
-As mentioned in the [authenticator](#authenticator) section, make sure you refer to the spawner's documentation to consider all settings before launching JupyterHub. In most cases the spawners provide drop-in replacement of the provided `IllumiDeskRoleDockerSpawner` class. However, setting spawners other than `IllumiDeskRoleDockerSpawner` may break compatibility with the grading services.
+As mentioned in the [authenticator](#authenticator) section, make sure you refer to the spawner's documentation to consider all settings before launching JupyterHub. In most cases the spawners provide drop-in replacement of the provided `IllumiDeskDockerSpawner` class. However, setting spawners other than `IllumiDeskDockerSpawner` may break compatibility with the grading services.
 
 ### Proxies
 
@@ -331,11 +331,7 @@ This setup uses JupyterHub's [configurable-http-proxy]((https://github.com/jupyt
 - Use one of images provided by the [`jupyter/docker-stacks`](https://github.com/jupyter/docker-stacks).
 - Make sure the image is on the host used by the spawner to launch the user's Jupyter Notebook.
 
-There are three notebook images:
-
-- [Student](roles/common/templates/Dockerfile.student.j2)
-- [Learner](roles/common/templates/Dockerfile.learner.j2)
-- [Grader](roles/common/templates/Dockerfile.grader.j2)
+Images are pulled from `DockerHub`, including the end-user base image. This base image comes pre installed with a script to enable Jupyter Notebook / Jupyter Lab extensions based on the user's LTI role.
 
 The nbgrader extensions are enabled within the images like so:
 
@@ -440,12 +436,7 @@ The services included with this setup rely on environment variables to work prop
 
 | Variable  |  Type | Description | Default Value |
 |---|---|---|---|
-| DOCKER_LEARNER_IMAGE | `string` | Docker image used by users with the Learner role. | `illumidesk/learner-notebook:latest` |
-| DOCKER_INSTRUCTOR_IMAGE | `string` | Docker image used by users with the Instructor role. | `illumidesk/instructor-notebook:latest` |
-| DOCKER_STANDARD_IMAGE | `string` | Docker image used by users without an assigned role. | `illumidesk/base-notebook:latest` |
-| DOCKER_THEIA_IMAGE | `string` | Docker image used for the THEIA IDE | `illumidesk/theia:latest` |
-| DOCKER_RSTUDIO_IMAGE | `string` | Docker image used for RStudio | `illumidesk/rstudio:latest` |
-| DOCKER_VSCODE_IMAGE | `string` | Docker image used for VS Code | `illumidesk/vscode:latest` |
+| DOCKER_USER_IMAGE | `string` | Docker image used by users without an assigned role. | `illumidesk/base-notebook:latest` |
 | DOCKER_NETWORK_NAME | `string` | Docker network name for docker-compose and dockerspawner | `jupyter-network` |
 | DOCKER_NOTEBOOK_DIR | `string` | Working directory for Jupyter Notebooks | `/home/jovyan` |
 | EXCHANGE_DIR | `string` | Exchange directory path  | `/srv/nbgrader/exchange` |

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -12,11 +12,11 @@ docker_jhub_base_image: "{{ docker_jhub_base_image_param | default('jupyterhub/j
 # built jupyterhub image
 docker_illumidesk_jhub_image: "{{ docker_illumidesk_jhub_image_param | default('illumidesk/jupyterhub:latest') }}"
 
-# illumidesk notebooks base and custom images
-docker_illumidesk_notebook_base_image: "{{ docker_illumidesk_notebook_base_image_param | default('illumidesk/base-notebook:latest') }}"
-docker_illumidesk_notebook_learner_image: "{{ docker_illumidesk_notebook_learner_image_param | default('illumidesk/learner-notebook:latest') }}"
+# illumidesk notebooks base image
+docker_illumidesk_notebook_user_image: "{{ docker_illumidesk_notebook_base_image_param | default('illumidesk/full-notebook:latest') }}"
+
+# illumidesk grader notebook image
 docker_illumidesk_notebook_grader_image: "{{ docker_illumidesk_notebook_grader_image_param | default('illumidesk/grader-notebook:latest') }}"
-docker_illumidesk_notebook_instructor_image: "{{ docker_illumidesk_notebook_instructor_image_param | default('illumidesk/instructor-notebook:latest') }}"
 
 # setup-course image
 docker_setup_course_image: "{{ docker_setup_course_image_param | default('illumidesk/setup-course:latest') }}"

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
@@ -4,7 +4,8 @@ import sys
 from dockerspawner import DockerSpawner  # noqa: F401
 
 from illumidesk.apis.announcement_service import ANNOUNCEMENT_JHUB_SERVICE_DEFINITION
-
+from illumidesk.spawners.hooks import custom_auth_state_hook
+from illumidesk.spawners.hooks import custom_pre_spawn_hook
 
 c = get_config()
 
@@ -190,6 +191,12 @@ c.DockerSpawner.extra_create_kwargs = {'user': '0'}
 
 # these env vars are set within the docker image but add them here for good measure
 c.DockerSpawner.environment = {'NB_UID': '1000', 'NB_GID': '100', 'NB_USER': 'jovyan'}
+
+# Get additional authentication data from the authenticator
+c.DockerSpawner.auth_state_hook = custom_auth_state_hook
+
+# The customized pre_spawn_hook creates user folders for non system users
+c.DockerSpawner.pre_spawn_hook = custom_pre_spawn_hook
 
 ##########################################
 # END CUSTOM DOCKERSPAWNER

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
@@ -77,7 +77,7 @@ c.JupyterHub.redirect_to_server = False
 base_url = os.environ.get('JUPYTERHUB_BASE_URL') or ''
 c.JupyterHub.base_url = base_url
 
-# Do not redirect user to his/her server (if running)
+# redirect users to their servers by default
 c.JupyterHub.redirect_to_server = True
 
 ##########################################

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from dockerspawner import DockerSpawner  # noqa: F401
+
 from illumidesk.apis.announcement_service import ANNOUNCEMENT_JHUB_SERVICE_DEFINITION
 
 

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti11.py
@@ -4,7 +4,7 @@ from illumidesk.apis.setup_course_service import get_current_service_definitions
 from illumidesk.authenticators.authenticator import LTI11Authenticator
 from illumidesk.authenticators.authenticator import setup_course_hook
 from illumidesk.grades.handlers import SendGradesHandler
-from illumidesk.spawners.spawners import IllumiDeskRoleDockerSpawner
+from illumidesk.spawners.spawners import IllumiDeskDockerSpawner
 
 
 c = get_config()
@@ -19,8 +19,8 @@ load_subconfig('/etc/jupyterhub/jupyterhub_config_base.py')  # noqa: F821
 # LTI 1.1 authenticator class.
 c.JupyterHub.authenticator_class = LTI11Authenticator
 
-# Spawn containers with by role
-c.JupyterHub.spawner_class = IllumiDeskRoleDockerSpawner
+# Spawn end-user container and enable extensions by role
+c.JupyterHub.spawner_class = IllumiDeskDockerSpawner
 
 ##########################################
 # END JUPYTERHUB APPLICATION

--- a/ansible/roles/jupyterhub/files/jupyterhub_config_lti13.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_lti13.py
@@ -10,7 +10,7 @@ from illumidesk.grades.handlers import SendGradesHandler
 from illumidesk.lti13.handlers import LTI13ConfigHandler
 from illumidesk.lti13.handlers import LTI13JWKSHandler
 
-from illumidesk.spawners.spawners import IllumiDeskRoleDockerSpawner
+from illumidesk.spawners.spawners import IllumiDeskDockerSpawner
 
 c = get_config()
 
@@ -26,7 +26,7 @@ load_subconfig('/etc/jupyterhub/jupyterhub_config_base.py')  # noqa: F821
 c.JupyterHub.authenticator_class = LTI13Authenticator
 
 # Spawn containers with by role
-c.JupyterHub.spawner_class = IllumiDeskRoleDockerSpawner
+c.JupyterHub.spawner_class = IllumiDeskDockerSpawner
 
 # created after installing app in lms
 c.LTI13Authenticator.client_id = os.environ.get('LTI13_CLIENT_ID')

--- a/src/illumidesk/apis/jupyterhub_api.py
+++ b/src/illumidesk/apis/jupyterhub_api.py
@@ -101,7 +101,7 @@ class JupyterHubAPI(LoggingConfigurable):
 
         Args:
           users: a user list
-        
+
         Returns:
           Response from the endpoint
         """
@@ -116,7 +116,7 @@ class JupyterHubAPI(LoggingConfigurable):
 
         Args:
           username: the user's username to create
-        
+
         Returns:
           Response from the endpoint
         """

--- a/src/illumidesk/apis/setup_course_service.py
+++ b/src/illumidesk/apis/setup_course_service.py
@@ -48,7 +48,7 @@ async def register_new_service(data: Dict[str, str]) -> str:
             'course_id': course_id,
             'domain': handler.request.host,
         })```
-    
+
     Returns: the response as json
 
     """

--- a/src/illumidesk/authenticators/handlers.py
+++ b/src/illumidesk/authenticators/handlers.py
@@ -63,7 +63,7 @@ class LTI13LoginHandler(OAuthLoginHandler):
         References:
         https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
         http://www.imsglobal.org/spec/lti/v1p3/#additional-login-parameters-0
-        
+
         Args:
           client_id: used to identify the tool's installation with a platform
           redirect_uri: redirect url specified during tool installation (callback url)

--- a/src/illumidesk/authenticators/utils.py
+++ b/src/illumidesk/authenticators/utils.py
@@ -60,7 +60,7 @@ class LTIUtils(LoggingConfigurable):
 
         Args:
           email: A valid email address
-        
+
         Returns:
           username: A username string
 

--- a/src/illumidesk/authenticators/validator.py
+++ b/src/illumidesk/authenticators/validator.py
@@ -238,10 +238,10 @@ class LTI13LaunchValidator(LoggingConfigurable):
     def validate_login_request(self, args: Dict[str, Any]) -> bool:
         """
         Validates step 1 of authentication request.
-        
+
         Args:
           args: dictionary that represents keys/values sent in authentication request
-        
+
         Returns:
           True if the validation is ok, false otherwise
         """

--- a/src/illumidesk/grades/handlers.py
+++ b/src/illumidesk/grades/handlers.py
@@ -21,12 +21,12 @@ class SendGradesHandler(BaseHandler):
         Receives a request with the course name and the assignment name as path parameters
         which then uses the appropriate class to send grades to the platform based on the
         LTI authenticator version (1.1 or 1.3).
-        
+
         Arguments:
           course_id: course name which has been previously normalized by the LTIUtils.normalize_string
             function.
           assignment_name: assignment name which should coincide with the assignment name within the LMS.
-          
+
         Raises:
           GradesSenderCriticalError if there was a critical error when either extracting grades from the db
             or sending grades to the tool consumer / platform.

--- a/src/illumidesk/lti13/auth.py
+++ b/src/illumidesk/lti13/auth.py
@@ -24,7 +24,7 @@ async def get_lms_access_token(token_endpoint: str, private_key_path: str, clien
         token_endpoint: The url that will be used to make the request
         private_key_path: specify where the pem is
         client_id: For LTI 1.3 the Client ID that was obtained with the tool setup
-    
+
     Returns:
         A json with the token value
     """

--- a/src/illumidesk/lti13/handlers.py
+++ b/src/illumidesk/lti13/handlers.py
@@ -20,7 +20,7 @@ class LTI13ConfigHandler(BaseHandler):
         """
         Gets the JSON config which is used by LTI platforms
         to install the external tool.
-        
+
         - The extensions key contains settings for specific vendors, such as canvas,
         moodle, edx, among others.
         - The tool uses public settings by default. Users that wish to install the tool with

--- a/src/illumidesk/setup_course/app.py
+++ b/src/illumidesk/setup_course/app.py
@@ -80,7 +80,7 @@ def update_jupyterhub_config(course: Course):
     We can add groups and users with the REST API, but not services. Therefore
     add new services to the JupyterHub.services section within the jupyterhub
     configuration file (jupyterhub_config.py).
-    
+
     """
     jupyterhub_config_json = Path(JSON_FILE_PATH)
     # Lock file to manage jupyterhub_config.py

--- a/src/illumidesk/setup_course/course.py
+++ b/src/illumidesk/setup_course/course.py
@@ -30,7 +30,7 @@ class Course:
         grader_root: Grader's home path
         course_root: Course's root path
         token: JupyterHub API token used to authenticat requests with the Hub
-        
+
         uid: Grader's user id
         gid: Grader's group id
         is_new_setup: True indicates a new setup, False otherwise
@@ -75,7 +75,7 @@ class Course:
     async def setup(self):
         """
         Function to bootstrap new course setup
-        
+
         Returns:
             is_new_setup: boolean to indicate whether or not the this setup
             function executed the functions to set up a new course.

--- a/src/illumidesk/spawners/spawners.py
+++ b/src/illumidesk/spawners/spawners.py
@@ -30,7 +30,7 @@ class IllumiDeskDockerSpawner(DockerSpawner):
         Returns:
             Dict: returns collection that represents the volumes the container should mount (bind)
         """
-        binds = self._volumes_to_binds(volumes, binds, mode)
+        binds = super()._volumes_to_binds(volumes, binds, mode)
         if self.load_shared_folder_with_instructor is False and user_is_an_instructor(self.environment['USER_ROLE']):
             self.log.debug(f'binds loaded from volumes setting: {binds}')
             shared_vol_key = ''

--- a/src/illumidesk/spawners/spawners.py
+++ b/src/illumidesk/spawners/spawners.py
@@ -9,8 +9,8 @@ from traitlets.traitlets import Bool
 
 
 class IllumiDeskBaseDockerSpawner(DockerSpawner):
-    """
-    Extends the DockerSpawner by defining the common behavior for our Spwaners that work with LTI versions 1.1 and 1.3
+    """Extends the DockerSpawner by defining the common behavior for our Spwaners that work
+    with LTI versions 1.1 and 1.3
     """
 
     load_shared_folder_with_instructor = Bool(
@@ -19,8 +19,8 @@ class IllumiDeskBaseDockerSpawner(DockerSpawner):
         help="Mount the shared folder with Instructor role (Used with shared_folder_enabled env-var).",
     )
 
-    def _volumes_to_bind(self, volumes, binds, mode="rw"):
-        """[summary]
+    def _volumes_to_bind(self, volumes: dict, binds: dict, mode: str = "rw"):
+        """Binds volumes when spawning containers.
 
         Args:
             volumes ([type]): [description]

--- a/src/illumidesk/spawners/spawners.py
+++ b/src/illumidesk/spawners/spawners.py
@@ -1,14 +1,13 @@
 from dockerspawner import DockerSpawner
 
-from illumidesk.authenticators.utils import user_is_an_instructor
+from typing import Dict
 
-from illumidesk.spawners.hooks import custom_auth_state_hook
-from illumidesk.spawners.hooks import custom_pre_spawn_hook
+from illumidesk.authenticators.utils import user_is_an_instructor
 
 from traitlets.traitlets import Bool
 
 
-class IllumiDeskBaseDockerSpawner(DockerSpawner):
+class IllumiDeskDockerSpawner(DockerSpawner):
     """Extends the DockerSpawner by defining the common behavior for our Spwaners that work
     with LTI versions 1.1 and 1.3
     """
@@ -19,18 +18,19 @@ class IllumiDeskBaseDockerSpawner(DockerSpawner):
         help="Mount the shared folder with Instructor role (Used with shared_folder_enabled env-var).",
     )
 
-    def _volumes_to_bind(self, volumes: dict, binds: dict, mode: str = "rw"):
-        """Binds volumes when spawning containers.
+    def _volumes_to_binds(self, volumes: dict, binds: dict, mode: str = "rw") -> Dict[str, str]:
+        """Binds volumes when spawning containers. This function overrides the DockerSpawner method to
+        add determine shared directory permissions based on LTI role.
 
         Args:
-            volumes ([type]): [description]
-            binds ([type]): [description]
-            mode (str, optional): [description]. Defaults to "rw".
+            volumes: Volumes to mount.
+            binds: Internal volumes to bind after the volumens are mounted.
+            mode: Volume permissions. Defaults to "rw".
 
         Returns:
-            [type]: [description]
+            Dict: returns collection that represents the volumes the container should mount (bind)
         """
-        binds = self._volumes_to_bind(volumes, binds, mode)
+        binds = self._volumes_to_binds(volumes, binds, mode)
         if self.load_shared_folder_with_instructor is False and user_is_an_instructor(self.environment['USER_ROLE']):
             self.log.debug(f'binds loaded from volumes setting: {binds}')
             shared_vol_key = ''
@@ -43,31 +43,3 @@ class IllumiDeskBaseDockerSpawner(DockerSpawner):
                 del binds[shared_vol_key]
                 self.log.debug(f'binds without the shared folder: {binds}')
         return binds
-
-    def auth_state_hook(self, spawner: DockerSpawner, auth_state: dict) -> None:
-        """[summary]
-
-        Args:
-            spawner (DockerSpawner): [description]
-            auth_state (dict): [description]
-        """
-        # call our custom hook from here without issue related with 'invalid arguments number given'
-        custom_auth_state_hook(spawner, auth_state)
-
-    def pre_spawn_hook(self, spawner) -> None:
-        """[summary]
-
-        Args:
-            spawner ([type]): [description]
-        """
-        custom_pre_spawn_hook(spawner)
-
-    def start(self) -> None:
-        """[summary]
-
-        Returns:
-            [type]: [description]
-        """
-        self.image = self._get_image_name()
-        self.log.debug('Starting with image: %s' % self.image)
-        return super().start()

--- a/src/tests/illumidesk/conftest.py
+++ b/src/tests/illumidesk/conftest.py
@@ -371,7 +371,7 @@ def make_http_response() -> HTTPResponse:
             {"content-type": "application/json"}
         effective_url: final location of the resource after following any redirects
         body: dictionary that represents the StringIO (buffer) body
-        
+
         Returns:
         A tornado.client.HTTPResponse object
         """

--- a/src/tests/illumidesk/conftest.py
+++ b/src/tests/illumidesk/conftest.py
@@ -267,12 +267,9 @@ def grades_controlfile_reset_file_loaded():
 @pytest.fixture(scope='function')
 def setup_image_environ(monkeypatch):
     """
-    Set the enviroment variables used to identify images assigned by
-    role and/or workspace type.
+    Set the enviroment variables used to identify the end user image.
     """
-    monkeypatch.setenv('DOCKER_STANDARD_IMAGE', 'standard_image')
-    monkeypatch.setenv('DOCKER_LEARNER_IMAGE', 'learner_image')
-    monkeypatch.setenv('DOCKER_INSTRUCTOR_IMAGE', 'instructor_image')
+    monkeypatch.setenv('DOCKER_USER_IMAGE', 'standard_image')
 
 
 @pytest.fixture(scope='function')

--- a/src/tests/illumidesk/spawners/test_hooks.py
+++ b/src/tests/illumidesk/spawners/test_hooks.py
@@ -1,6 +1,6 @@
 import pytest
 from illumidesk.spawners.hooks import custom_auth_state_hook
-from illumidesk.spawners.spawners import IllumiDeskRoleDockerSpawner
+from illumidesk.spawners.spawners import IllumiDeskDockerSpawner
 
 
 @pytest.mark.asyncio
@@ -8,7 +8,7 @@ async def test_ensure_environment_assigned_to_user_role_from_auth_state_in_spawn
     """
     Does the user's docker container environment reflect his/her role?
     """
-    sut = IllumiDeskRoleDockerSpawner()
+    sut = IllumiDeskDockerSpawner()
     custom_auth_state_hook(sut, auth_state_dict['auth_state'])
     # make sure the hook set the environment variables
     assert sut.environment['USER_ROLE'] == 'Learner'

--- a/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
+++ b/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
@@ -17,7 +17,7 @@ def test_base_spawner_does_not_consider_shared_folder_with_instructor_role_when_
     sut.environment['USER_ROLE'] = 'Instructor'
     sut.user = mock_jhub_user()
     volumes_to_mount = {'mnt_root/my-org/shared/': 'home/jovyan/shared'}
-    binds = sut._volumes_to_binds(volumes=volumes_to_mount, binds={})
+    binds = sut._volumes_to_bind(volumes=volumes_to_mount, binds={})
     assert len(binds) == 0
 
 
@@ -31,7 +31,7 @@ def test_base_spawner_load_shared_folder_with_instructor_role_when_jhub_setting_
     sut.environment['USER_ROLE'] = 'Instructor'
     sut.user = mock_jhub_user()
     volumes_to_mount = {'mnt_root/my-org/shared/': 'home/jovyan/shared'}
-    binds = sut._volumes_to_binds(volumes=volumes_to_mount, binds={})
+    binds = sut._volumes_to_bind(volumes=volumes_to_mount, binds={})
     assert len(binds) == 1
 
 
@@ -45,12 +45,12 @@ def test_base_spawner_returns_the_shared_folder_with_learner_role_not_matter_the
     sut.environment['USER_ROLE'] = 'Learner'
     sut.user = mock_jhub_user()
     volumes_to_mount = {'mnt_root/my-org/shared/': 'home/jovyan/shared'}
-    binds = sut._volumes_to_binds(volumes=volumes_to_mount, binds={})
+    binds = sut._volumes_to_bind(volumes=volumes_to_mount, binds={})
     # First case (setting is not used)
     assert len(binds) == 1
     sut.load_shared_folder_with_instructor = False
     volumes_to_mount = {'mnt_root/my-org/shared/': 'home/jovyan/shared'}
-    binds = sut._volumes_to_binds(volumes=volumes_to_mount, binds={})
+    binds = sut._volumes_to_bind(volumes=volumes_to_mount, binds={})
     # First case (setting is used)
     assert len(binds) == 1
 

--- a/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
+++ b/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
@@ -15,7 +15,7 @@ def test_base_spawner_does_not_consider_shared_folder_with_instructor_role_when_
     sut.environment['USER_ROLE'] = 'Instructor'
     sut.user = mock_jhub_user()
     volumes_to_mount = {'mnt_root/my-org/shared/': 'home/jovyan/shared'}
-    binds = sut._volumes_to_bind(volumes=volumes_to_mount, binds={})
+    binds = sut._volumes_to_binds(volumes=volumes_to_mount, binds={})
     assert len(binds) == 0
 
 
@@ -29,7 +29,7 @@ def test_base_spawner_load_shared_folder_with_instructor_role_when_jhub_setting_
     sut.environment['USER_ROLE'] = 'Instructor'
     sut.user = mock_jhub_user()
     volumes_to_mount = {'mnt_root/my-org/shared/': 'home/jovyan/shared'}
-    binds = sut._volumes_to_bind(volumes=volumes_to_mount, binds={})
+    binds = sut._volumes_to_binds(volumes=volumes_to_mount, binds={})
     assert len(binds) == 1
 
 
@@ -43,12 +43,12 @@ def test_base_spawner_returns_the_shared_folder_with_learner_role_not_matter_the
     sut.environment['USER_ROLE'] = 'Learner'
     sut.user = mock_jhub_user()
     volumes_to_mount = {'mnt_root/my-org/shared/': 'home/jovyan/shared'}
-    binds = sut._volumes_to_bind(volumes=volumes_to_mount, binds={})
+    binds = sut._volumes_to_binds(volumes=volumes_to_mount, binds={})
     # First case (setting is not used)
     assert len(binds) == 1
     sut.load_shared_folder_with_instructor = False
     volumes_to_mount = {'mnt_root/my-org/shared/': 'home/jovyan/shared'}
-    binds = sut._volumes_to_bind(volumes=volumes_to_mount, binds={})
+    binds = sut._volumes_to_binds(volumes=volumes_to_mount, binds={})
     # First case (setting is used)
     assert len(binds) == 1
 

--- a/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
+++ b/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
@@ -1,19 +1,17 @@
-import os
 import types
 
 from dockerspawner.dockerspawner import DockerSpawner
 
-from illumidesk.spawners.spawners import IllumiDeskBaseDockerSpawner
-from illumidesk.spawners.spawners import IllumiDeskRoleDockerSpawner
+from illumidesk.spawners.spawners import IllumiDeskDockerSpawner
 
 
 def test_base_spawner_does_not_consider_shared_folder_with_instructor_role_when_jhub_setting_is_False(
     setup_image_environ, mock_jhub_user
 ):
     """
-    Does the IllumiDeskBaseDockerSpawner class exclude the shared folder for instructors when load_shared_folder_with_instructor is False?
+    Does the IllumiDeskDockerSpawner class exclude the shared folder for instructors when load_shared_folder_with_instructor is False?
     """
-    sut = IllumiDeskBaseDockerSpawner(load_shared_folder_with_instructor=False)
+    sut = IllumiDeskDockerSpawner(load_shared_folder_with_instructor=False)
     sut.environment['USER_ROLE'] = 'Instructor'
     sut.user = mock_jhub_user()
     volumes_to_mount = {'mnt_root/my-org/shared/': 'home/jovyan/shared'}
@@ -25,9 +23,9 @@ def test_base_spawner_load_shared_folder_with_instructor_role_when_jhub_setting_
     setup_image_environ, mock_jhub_user
 ):
     """
-    Does the IllumiDeskBaseDockerSpawner class load the shared folder for instructors?
+    Does the IllumiDeskDockerSpawner class load the shared folder for instructors?
     """
-    sut = IllumiDeskBaseDockerSpawner(load_shared_folder_with_instructor=True)
+    sut = IllumiDeskDockerSpawner(load_shared_folder_with_instructor=True)
     sut.environment['USER_ROLE'] = 'Instructor'
     sut.user = mock_jhub_user()
     volumes_to_mount = {'mnt_root/my-org/shared/': 'home/jovyan/shared'}
@@ -39,9 +37,9 @@ def test_base_spawner_returns_the_shared_folder_with_learner_role_not_matter_the
     setup_image_environ, mock_jhub_user
 ):
     """
-    Does the IllumiDeskBaseDockerSpawner class consider the shared folder for learners?
+    Does the IllumiDeskDockerSpawner class consider the shared folder for learners?
     """
-    sut = IllumiDeskBaseDockerSpawner()
+    sut = IllumiDeskDockerSpawner()
     sut.environment['USER_ROLE'] = 'Learner'
     sut.user = mock_jhub_user()
     volumes_to_mount = {'mnt_root/my-org/shared/': 'home/jovyan/shared'}
@@ -53,50 +51,6 @@ def test_base_spawner_returns_the_shared_folder_with_learner_role_not_matter_the
     binds = sut._volumes_to_bind(volumes=volumes_to_mount, binds={})
     # First case (setting is used)
     assert len(binds) == 1
-
-
-def test_get_image_name_returns_correct_image_for_student_role(setup_image_environ, mock_jhub_user):
-    """
-    Does the internal get_image_name method return the correct image with the student role?
-    """
-    sut = IllumiDeskRoleDockerSpawner()
-    sut.environment['USER_ROLE'] = 'Student'
-    sut.user = mock_jhub_user()
-
-    assert sut._get_image_name() == os.environ.get('DOCKER_LEARNER_IMAGE')
-
-
-def test_get_image_name_returns_correct_image_for_learner_role(setup_image_environ, mock_jhub_user):
-    """
-    Does the internal get_image_name method return student image when using the learner role?
-    """
-    sut = IllumiDeskRoleDockerSpawner()
-    sut.environment['USER_ROLE'] = 'Learner'
-    sut.user = mock_jhub_user()
-
-    assert sut._get_image_name() == os.environ.get('DOCKER_LEARNER_IMAGE')
-
-
-def test_get_image_name_returns_correct_image_for_Instructor_role(setup_image_environ, mock_jhub_user):
-    """
-    Does the internal get_image_name method return instructor image when using the Instructor role?
-    """
-    sut = IllumiDeskRoleDockerSpawner()
-    sut.environment['USER_ROLE'] = 'Instructor'
-    sut.user = mock_jhub_user()
-
-    assert sut._get_image_name() == os.environ.get('DOCKER_INSTRUCTOR_IMAGE')
-
-
-def test_get_image_name_returns_Standard_image_for_unknown_role(setup_image_environ, mock_jhub_user):
-    """
-    Does the internal get_image_name method return Standard image when using an unknown role?
-    """
-    sut = IllumiDeskRoleDockerSpawner()
-    sut.environment['USER_ROLE'] = 'any-value'
-    sut.user = mock_jhub_user()
-
-    assert sut._get_image_name() == os.environ.get('DOCKER_STANDARD_IMAGE')
 
 
 def test_dockerspawner_uses_raw_username_in_format_volume_name():


### PR DESCRIPTION
- Updates spawner to remove logic of spawning user image by LTI role
- Update tests

This update relies on the latest notebook version from `illumidesk/docker-stacks` that enables extensions using the `before-notebook.d` hook based on the user role obtained from the `auth_state`.