### PR TITLE
Add assignments only when LTI role is Student or Learner

### DIFF
--- a/src/illumidesk/authenticators/constants.py
+++ b/src/illumidesk/authenticators/constants.py
@@ -317,6 +317,11 @@ LTI13_ROLES = {
 }
 
 # the list of roles that recognize a user as a Student
-DEFAULT_ROLE_NAMES_FOR_STUDENT = ['student', 'learner']
+DEFAULT_ROLE_NAMES_FOR_STUDENT = [
+    'student',
+    'learner',
+    'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Learner',
+    'http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student',
+]
 # the list of roles that recognize a user as an Instructor
 DEFAULT_ROLE_NAMES_FOR_INSTRUCTOR = ['instructor', 'urn:lti:role:ims/lis/teachingassistant']

--- a/src/tests/illumidesk/authenticators/test_lti11_authenticator.py
+++ b/src/tests/illumidesk/authenticators/test_lti11_authenticator.py
@@ -229,12 +229,11 @@ async def test_authenticator_uses_lti_grades_sender_control_file_with_instructor
 
 @pytest.mark.asyncio
 @patch('illumidesk.authenticators.validator.LTI11LaunchValidator')
-async def test_authenticator_calls_create_assignment_method_with_user_role_is_student(
+async def test_lti11authenticator_calls_create_assignment_method_with_user_role_is_student(
     lti11_validator, make_lti11_success_authentication_request_args, mock_nbhelper, gradesender_controlfile_mock
 ):
     """
-    Does the authenticator call the create_assignment_in_nbgrader method with the user has the Student
-    or Learner?
+    Does the authenticator call the create_assignment_in_nbgrader method with the user has the Student role?
     """
     with patch.object(LTI11LaunchValidator, 'validate_launch_request', return_value=True):
         authenticator = LTI11Authenticator()
@@ -251,12 +250,11 @@ async def test_authenticator_calls_create_assignment_method_with_user_role_is_st
 
 @pytest.mark.asyncio
 @patch('illumidesk.authenticators.validator.LTI11LaunchValidator')
-async def test_authenticator_calls_create_assignment_method_with_user_role_is_learner(
+async def test_lti11authenticator_calls_create_assignment_method_with_user_role_is_learner(
     lti11_validator, make_lti11_success_authentication_request_args, mock_nbhelper, gradesender_controlfile_mock
 ):
     """
-    Does the authenticator call the create_assignment_in_nbgrader method with the user has the Student
-    or Learner?
+    Does the authenticator call the create_assignment_in_nbgrader method with the user has the Learner role?
     """
     with patch.object(LTI11LaunchValidator, 'validate_launch_request', return_value=True):
         authenticator = LTI11Authenticator()
@@ -273,12 +271,11 @@ async def test_authenticator_calls_create_assignment_method_with_user_role_is_le
 
 @pytest.mark.asyncio
 @patch('illumidesk.authenticators.validator.LTI11LaunchValidator')
-async def test_authenticator_calls_create_assignment_method_with_user_role_is_instructor(
+async def test_lti11authenticator_calls_create_assignment_method_with_user_role_is_instructor(
     lti11_validator, make_lti11_success_authentication_request_args, mock_nbhelper, gradesender_controlfile_mock
 ):
     """
-    Does the authenticator call the create_assignment_in_nbgrader method with the user has the Student
-    or Learner?
+    Does the authenticator call the create_assignment_in_nbgrader method with the user has the Instructor role?
     """
     with patch.object(LTI11LaunchValidator, 'validate_launch_request', return_value=True):
         authenticator = LTI11Authenticator()

--- a/src/tests/illumidesk/authenticators/test_lti11_authenticator.py
+++ b/src/tests/illumidesk/authenticators/test_lti11_authenticator.py
@@ -11,6 +11,7 @@ from illumidesk.authenticators.validator import LTI11LaunchValidator
 from illumidesk.authenticators.authenticator import LTI11Authenticator
 from illumidesk.authenticators.authenticator import LTIUtils
 from illumidesk.grades.senders import LTIGradesSenderControlFile
+from illumidesk.apis.nbgrader_service import NbGraderServiceHelper
 
 
 @pytest.fixture(scope='function')
@@ -224,6 +225,72 @@ async def test_authenticator_uses_lti_grades_sender_control_file_with_instructor
 
                 _ = await authenticator.authenticate(handler, None)
                 assert mock_register_data.called
+
+
+@pytest.mark.asyncio
+@patch('illumidesk.authenticators.validator.LTI11LaunchValidator')
+async def test_authenticator_calls_create_assignment_method_with_user_role_is_student(
+    lti11_validator, make_lti11_success_authentication_request_args, mock_nbhelper, gradesender_controlfile_mock
+):
+    """
+    Does the authenticator call the create_assignment_in_nbgrader method with the user has the Student
+    or Learner?
+    """
+    with patch.object(LTI11LaunchValidator, 'validate_launch_request', return_value=True):
+        authenticator = LTI11Authenticator()
+        args = make_lti11_success_authentication_request_args('canvas', 'Student')
+        handler = Mock(
+            spec=RequestHandler,
+            get_secure_cookie=Mock(return_value=json.dumps(['key', 'secret'])),
+            request=Mock(arguments=args, headers={}, items=[],),
+        )
+        with patch.object(NbGraderServiceHelper, 'create_assignment_in_nbgrader') as mock_create_assignment:
+            result = await authenticator.authenticate(handler, None)
+            assert mock_create_assignment.called
+
+
+@pytest.mark.asyncio
+@patch('illumidesk.authenticators.validator.LTI11LaunchValidator')
+async def test_authenticator_calls_create_assignment_method_with_user_role_is_learner(
+    lti11_validator, make_lti11_success_authentication_request_args, mock_nbhelper, gradesender_controlfile_mock
+):
+    """
+    Does the authenticator call the create_assignment_in_nbgrader method with the user has the Student
+    or Learner?
+    """
+    with patch.object(LTI11LaunchValidator, 'validate_launch_request', return_value=True):
+        authenticator = LTI11Authenticator()
+        args = make_lti11_success_authentication_request_args('canvas', 'Learner')
+        handler = Mock(
+            spec=RequestHandler,
+            get_secure_cookie=Mock(return_value=json.dumps(['key', 'secret'])),
+            request=Mock(arguments=args, headers={}, items=[],),
+        )
+        with patch.object(NbGraderServiceHelper, 'create_assignment_in_nbgrader') as mock_create_assignment:
+            result = await authenticator.authenticate(handler, None)
+            assert mock_create_assignment.called
+
+
+@pytest.mark.asyncio
+@patch('illumidesk.authenticators.validator.LTI11LaunchValidator')
+async def test_authenticator_calls_create_assignment_method_with_user_role_is_instructor(
+    lti11_validator, make_lti11_success_authentication_request_args, mock_nbhelper, gradesender_controlfile_mock
+):
+    """
+    Does the authenticator call the create_assignment_in_nbgrader method with the user has the Student
+    or Learner?
+    """
+    with patch.object(LTI11LaunchValidator, 'validate_launch_request', return_value=True):
+        authenticator = LTI11Authenticator()
+        args = make_lti11_success_authentication_request_args('canvas', 'Instructor')
+        handler = Mock(
+            spec=RequestHandler,
+            get_secure_cookie=Mock(return_value=json.dumps(['key', 'secret'])),
+            request=Mock(arguments=args, headers={}, items=[],),
+        )
+        with patch.object(NbGraderServiceHelper, 'create_assignment_in_nbgrader') as mock_create_assignment:
+            result = await authenticator.authenticate(handler, None)
+            assert not mock_create_assignment.called
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Verify if user has the student or learner role in authenticator with helper methods
- Update LTI 1.1 and LTI 1.3 authenticators to add assignment name if the user's role is `Student` or `Learner`
- Update tests

Closes #307 