### PR TITLE
Update base spawner config setting with image env var

### DIFF
--- a/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
+++ b/ansible/roles/jupyterhub/files/jupyterhub_config_base.py
@@ -139,6 +139,9 @@ c.Authenticator.enable_auth_state = True
 # Limit memory
 c.Spawner.mem_limit = os.environ.get('DOCKER_SPAWN_MEM_LIMIT') or '2G'
 
+# End user image
+c.Spawner.image = os.environ.get('DOCKER_END_USER_IMAGE') or 'illumidesk/full-notebook:latest'
+
 ##########################################
 # END GENERAL SPAWNER
 ##########################################

--- a/src/illumidesk/setup_course/course.py
+++ b/src/illumidesk/setup_course/course.py
@@ -222,7 +222,7 @@ class Course:
             docker_volumes[str(self.grader_shared_folder)] = {'bind': f'/home/{self.grader_name}/shared'}
         self.client.containers.run(
             detach=True,
-            image=os.environ.get('GRADER_SERVICE_IMAGE'),
+            image=os.environ.get('DOCKER_GRADER_IMAGE') or 'illumidesk/grader-notebook:latest',
             command=['start-notebook.sh', f'--group=formgrade-{self.course_id}'],
             environment=[
                 f'JUPYTERHUB_SERVICE_NAME={self.course_id}',

--- a/src/tests/illumidesk/conftest.py
+++ b/src/tests/illumidesk/conftest.py
@@ -269,7 +269,7 @@ def setup_image_environ(monkeypatch):
     """
     Set the enviroment variables used to identify the end user image.
     """
-    monkeypatch.setenv('DOCKER_USER_IMAGE', 'standard_image')
+    monkeypatch.setenv('DOCKER_END_USER_IMAGE', 'standard_image')
 
 
 @pytest.fixture(scope='function')
@@ -280,6 +280,7 @@ def setup_course_environ(monkeypatch, tmp_path, jupyterhub_api_environ):
     monkeypatch.setenv('MNT_ROOT', str(tmp_path))
     monkeypatch.setenv('NB_UID', '10001')
     monkeypatch.setenv('NB_GID', '100')
+    monkeypatch.setenv('DOCKER_GRADER_IMAGE', 'grader-image')
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
- Assigns the `DOCKER_END_USER_IMAGE` to the `Spawner.image` configurable
- Assigns the `DOCKER_GRADER_IMAGE` as a `Course` attribute