### PR TITLE
Normalize the course-id value before set auth_state

### DIFF
--- a/src/illumidesk/authenticators/authenticator.py
+++ b/src/illumidesk/authenticators/authenticator.py
@@ -338,6 +338,7 @@ class LTI13Authenticator(OAuthenticator):
 
         if validator.validate_launch_request(jwt_decoded):
             course_id = jwt_decoded['https://purl.imsglobal.org/spec/lti/claim/context']['label']
+            course_id = lti_utils.normalize_string(course_id)
             self.log.debug('Normalized course label is %s' % course_id)
             username = ''
             if 'email' in jwt_decoded and jwt_decoded['email']:


### PR DESCRIPTION
The auth_state was saving the original value from context label and it affected new methods that use the auth_state dict from the current user.