### PR TITLE
Fix typo in hosts.example

### DIFF
--- a/ansible/hosts.example
+++ b/ansible/hosts.example
@@ -71,7 +71,7 @@ all:
       # uncomment and change the value to False if you would like to leave the user's server
       # (container) in the running state after the user logs out of their session. This also applies
       # to when the cookie-based session expires (14 days by default).
-      # shutdown_on_logout = True
+      # shutdown_on_logout: True
 
       ## Authentication settings
       #-------------------


### PR DESCRIPTION
Replace `=` with `:` for `shutdown_on_logout` setting.