### PR TITLE
Default to resourcelink for assignment placements

### DIFF
--- a/src/illumidesk/lti13/handlers.py
+++ b/src/illumidesk/lti13/handlers.py
@@ -81,7 +81,7 @@ class LTI13ConfigHandler(BaseHandler):
                             },
                             {
                                 'placement': 'assignment_selection',
-                                'message_type': 'LtiDeepLinkingRequest',
+                                'message_type': 'LtiResourceLinkRequest',
                                 'target_link_uri': target_link_url,
                             },
                         ],


### PR DESCRIPTION
Updates the LTI 1.3 configuration endpoint to use the `LtiResourceLinkRequest` instead of the `LtiDeepLinkRequest`.