### PR TITLE
Use one database for each course within the organization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ venv:
 	test -d $(VENV_NAME) || virtualenv -p python3 $(VENV_NAME)
 	${PYTHON} -m pip install --upgrade pip
 	${PYTHON} -m pip install -r requirements.txt
-	${VENV_BIN}/ansible-galaxy collection install community.general --ignore-certs 
 
 deploy: prepare
 	${VENV_BIN}/ansible-playbook -i ansible/hosts \

--- a/README.md
+++ b/README.md
@@ -476,7 +476,6 @@ The services included with this setup rely on environment variables to work prop
 | POSTGRES_USER | `string` | Postgres database username | `jupyterhub` |
 | POSTGRES_PASSWORD | `string` | Postgres database password | `jupyterhub` |
 | POSTGRES_HOST | `string` | Postgres host | `jupyterhub-db` |
-| POSTGRES_NBGRADER_DB | `string` | Postgres database name for nbgrader| `nbgrader` |
 | POSTGRES_NBGRADER_HOST | `string` | Postgres host for Nbgrader | `postgres-nbgrader`  |
 | POSTGRES_NBGRADER_PASSWORD | `string` | Postgres password for Nbgrader | `nbgrader` |
 | POSTGRES_NBGRADER_PORT | `string` | Postgres port for Nbgrader | `5432` |
@@ -499,7 +498,6 @@ The services included with this setup rely on environment variables to work prop
 | MNT_ROOT | `string` | Notebook grader user id | `/mnt` |
 | NB_UID | `string` | Notebook grader user id | `10001` |
 | NB_GID | `string` | Notebook grader user id | `100` |
-| POSTGRES_NBGRADER_DB | `string` | Postgres database name for nbgrader| `nbgrader` |
 | POSTGRES_NBGRADER_HOST | `string` | Postgres host for Nbgrader | `postgres-nbgrader`  |
 | POSTGRES_NBGRADER_PASSWORD | `string` | Postgres password for Nbgrader | `nbgrader` |
 | POSTGRES_NBGRADER_PORT | `string` | Postgres port for Nbgrader | `5432` |

--- a/ansible/roles/jupyterhub/templates/docker-compose.yml.j2
+++ b/ansible/roles/jupyterhub/templates/docker-compose.yml.j2
@@ -53,6 +53,7 @@ services:
       - {{mnt_root}}:{{mnt_root}}
       - data:/srv/jupyterhub
       - {{ working_dir }}:{{ working_dir }}
+{% if 'rds.amazonaws.com' not in postgres_nbgrader_host%}
   {{postgres_nbgrader_host}}:
     image: {{docker_postgres_image}}
     container_name: {{postgres_nbgrader_host}}
@@ -63,6 +64,7 @@ services:
       - POSTGRES_PASSWORD={{postgres_nbgrader_password}}
     volumes:
       - db-nbgrader:/var/lib/postgresql/data
+{% endif %}
 {% if postgres_labs_enabled is sameas true %}
   postgres-labs:
     image: {{docker_postgres_image}}

--- a/ansible/roles/jupyterhub/templates/env.jhub.j2
+++ b/ansible/roles/jupyterhub/templates/env.jhub.j2
@@ -43,7 +43,6 @@ POSTGRES_NBGRADER_HOST={{postgres_nbgrader_host}}
 POSTGRES_NBGRADER_USER={{postgres_nbgrader_user}}
 POSTGRES_NBGRADER_PASSWORD={{postgres_nbgrader_password}}
 POSTGRES_NBGRADER_PORT={{postgres_nbgrader_port}}
-POSTGRES_NBGRADER_DB={{postgres_nbgrader_dbname}}
 
 MNT_HOME_DIR_UID=1000
 MNT_HOME_DIR_GID=100

--- a/ansible/roles/setup_course/templates/env.setup_course.j2
+++ b/ansible/roles/setup_course/templates/env.setup_course.j2
@@ -7,6 +7,9 @@ DOCKER_GRADER_IMAGE={{docker_illumidesk_grader_image}}
 # deployment working directory
 ILLUMIDESK_DIR={{working_dir}}
 
+# organization name used with nfs
+ORGANIZATION_NAME={{org_name}}
+
 # api token should be equal to value set for jupyterhub
 JUPYTERHUB_API_TOKEN={{jhub_api_token}}
 

--- a/ansible/roles/setup_course/templates/env.setup_course.j2
+++ b/ansible/roles/setup_course/templates/env.setup_course.j2
@@ -35,4 +35,3 @@ POSTGRES_NBGRADER_HOST={{postgres_nbgrader_host}}
 POSTGRES_NBGRADER_USER={{postgres_nbgrader_user}}
 POSTGRES_NBGRADER_PASSWORD={{postgres_nbgrader_password}}
 POSTGRES_NBGRADER_PORT={{postgres_nbgrader_port}}
-POSTGRES_NBGRADER_DB={{postgres_nbgrader_dbname}}

--- a/src/illumidesk/apis/nbgrader_service.py
+++ b/src/illumidesk/apis/nbgrader_service.py
@@ -23,6 +23,9 @@ nbgrader_db_user = os.environ.get('POSTGRES_NBGRADER_USER')
 
 org_name = os.environ.get('ORGANIZATION_NAME') or 'my-org'
 
+if not org_name:
+    raise EnvironmentError('ORGANIZATION_NAME env-var is not set')
+
 
 def nbgrader_format_db_url(course_id: str) -> str:
     """
@@ -48,7 +51,6 @@ class NbGraderServiceHelper:
         self.course_dir = f'/home/grader-{self.course_id}/{self.course_id}'
         self.uid = int(os.environ.get('NB_UID') or '10001')
         self.gid = int(os.environ.get('NB_GID') or '100')
-        self.org_name = os.environ.get('ORGANIZATION_NAME') or 'my-org'
 
         self.db_url = nbgrader_format_db_url(course_id)
         self.database_name = f'{org_name}_{self.course_id}'

--- a/src/illumidesk/apis/nbgrader_service.py
+++ b/src/illumidesk/apis/nbgrader_service.py
@@ -1,24 +1,46 @@
 import logging
 from pathlib import Path
+import psycopg2
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 import os
 import shutil
+
+from illumidesk.authenticators.utils import LTIUtils
 
 from nbgrader.api import Assignment
 from nbgrader.api import Course
 from nbgrader.api import Gradebook
 from nbgrader.api import InvalidEntry
 
-from illumidesk.authenticators.utils import LTIUtils
-
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
+nbgrader_db_host = os.environ.get('POSTGRES_NBGRADER_HOST')
+nbgrader_db_port = os.environ.get('POSTGRES_NBGRADER_PORT') or 5432
+nbgrader_db_password = os.environ.get('POSTGRES_NBGRADER_PASSWORD')
+nbgrader_db_user = os.environ.get('POSTGRES_NBGRADER_USER')
+
+org_name = os.environ.get('ORGANIZATION_NAME') or 'my-org'
+
+
+def nbgrader_format_db_url(course_id: str) -> str:
+    """
+    Returns the nbgrader database url with the format: <org_name>_<course-id>
+    """
+    course_id = LTIUtils().normalize_string(course_id)
+    database_name = f'{org_name}_{course_id}'
+    return (
+        f'postgresql://{nbgrader_db_user}:{nbgrader_db_password}@{nbgrader_db_host}:{nbgrader_db_port}/{database_name}'
+    )
+
 
 class NbGraderServiceHelper:
     """
+    Helper class to use the nbgrader database and gradebook
     """
-    def __init__(self, course_id: str):
+
+    def __init__(self, course_id: str, check_database_exists: bool = False):
         if not course_id:
             raise ValueError('course_id missing')
 
@@ -28,13 +50,22 @@ class NbGraderServiceHelper:
         self.gid = int(os.environ.get('NB_GID') or '100')
         self.org_name = os.environ.get('ORGANIZATION_NAME') or 'my-org'
 
-        # get nbgrader connection string from env vars
-        self.db_host = os.environ.get('POSTGRES_NBGRADER_HOST')
-        self.db_password = os.environ.get('POSTGRES_NBGRADER_PASSWORD')
-        self.db_port = os.environ.get('POSTGRES_NBGRADER_PORT')
-        self.db_name = os.environ.get('POSTGRES_NBGRADER_DB')
-        self.db_user = os.environ.get('POSTGRES_NBGRADER_USER')
-        self.db_url = f'postgresql://{self.db_user}:{self.db_password}@{self.db_host}:{self.db_port}/{self.db_name}'
+        self.db_url = nbgrader_format_db_url(course_id)
+        self.database_name = f'{org_name}_{self.course_id}'
+        if check_database_exists:
+            self.create_database_if_not_exists()
+
+    def create_database_if_not_exists(self) -> None:
+        with psycopg2.connect(
+            f'user={nbgrader_db_user} password={nbgrader_db_password} host={nbgrader_db_host}'
+        ) as conn:
+            conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(f'CREATE DATABASE "{self.database_name}";')
+            except psycopg2.errors.DuplicateDatabase:
+                logger.info(f'Database {self.database_name} exists')
+                pass
 
     def add_user_to_nbgrader_gradebook(self, username: str, lms_user_id: str) -> None:
         """

--- a/src/illumidesk/authenticators/authenticator.py
+++ b/src/illumidesk/authenticators/authenticator.py
@@ -255,7 +255,7 @@ class LTI11Authenticator(LTIAuthenticator):
                 control_file.register_data(assignment_name, lis_outcome_service_url, lms_user_id, lis_result_sourcedid)
             # Assignment creation
             if assignment_name:
-                nbgrader_service = NbGraderServiceHelper(course_id)
+                nbgrader_service = NbGraderServiceHelper(course_id, True)
                 self.log.debug(
                     'Creating a new assignment from the Authentication flow with title %s' % assignment_name
                 )
@@ -421,7 +421,7 @@ def process_additional_steps_for_resource_launch(
         and 'lineitems' in jwt_body_decoded['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']
     ):
         course_lineitems = jwt_body_decoded['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']['lineitems']
-    nbgrader_service = NbGraderServiceHelper(course_id)
+    nbgrader_service = NbGraderServiceHelper(course_id, True)
     nbgrader_service.update_course(lms_lineitems_endpoint=course_lineitems)
     if resource_link_title:
         # resource_link_title_normalize = lti_utils.normalize_string(resource_link_title)

--- a/src/illumidesk/grades/senders.py
+++ b/src/illumidesk/grades/senders.py
@@ -35,12 +35,7 @@ class GradesBaseSender:
         self.assignment_name = assignment_name
 
         # get nbgrader connection string from env vars
-        self.db_host = os.environ.get('POSTGRES_NBGRADER_HOST')
-        self.db_password = os.environ.get('POSTGRES_NBGRADER_PASSWORD')
-        self.db_port = os.environ.get('POSTGRES_NBGRADER_PORT')
-        self.db_name = os.environ.get('POSTGRES_NBGRADER_DB')
-        self.db_user = os.environ.get('POSTGRES_NBGRADER_USER')
-        self.db_url = f'postgresql://{self.db_user}:{self.db_password}@{self.db_host}:{self.db_port}/{self.db_name}'
+        self.nbgrader_helper = NbGraderServiceHelper(course_id)
 
     async def send_grades(self):
         raise NotImplementedError()
@@ -58,7 +53,7 @@ class GradesBaseSender:
         out = []
         max_score = 0
         # Create the connection to the gradebook database
-        with Gradebook(self.db_url, course_id=self.course_id) as gb:
+        with Gradebook(self.nbgrader_helper.db_url, course_id=self.course_id) as gb:
             try:
                 # retrieve the assignment record
                 assignment_row = gb.find_assignment(self.assignment_name)
@@ -162,8 +157,7 @@ class LTI13GradeSender(GradesBaseSender):
         self.lms_token_url = os.environ.get('LTI13_TOKEN_URL')
         self.lms_client_id = os.environ.get('LTI13_CLIENT_ID')
         # retrieve the course entity from nbgrader-gradebook
-        nbgrader_service = NbGraderServiceHelper(course_id)
-        course = nbgrader_service.get_course()
+        course = self.nbgrader_helper.get_course()
         self.course = course
         self.all_lineitems = []
         self.headers = {}

--- a/src/setup.py
+++ b/src/setup.py
@@ -45,6 +45,7 @@ setup(
         'nbgrader@git+https://github.com/IllumiDesk/nbgrader#egg=nbgrader-0.6.4',
         'oauthenticator==0.11.0',
         'pem==20.1.0',
+        'psycopg2-binary==2.8.6',
         'PyJWT==1.7.1',
         'pyjwkest==1.4.2',
         'pycryptodome==3.9.7',

--- a/src/tests/illumidesk/apis/test_nbgrader_service_helper.py
+++ b/src/tests/illumidesk/apis/test_nbgrader_service_helper.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import patch
 
 from illumidesk.apis.nbgrader_service import NbGraderServiceHelper
+from illumidesk.apis.nbgrader_service import nbgrader_format_db_url
 
 
 class TestNbGraderServiceBaseHelper:
@@ -85,12 +86,9 @@ class TestNbGraderServiceBaseHelper:
 
 
 class TestNbGraderServiceHelper:
-    def test_init_method_uses_env_vars_to_get_db_url(self, monkeypatch):
-        monkeypatch.setenv('POSTGRES_NBGRADER_HOST', 'test_host')
-        monkeypatch.setenv('POSTGRES_NBGRADER_USER', 'test_user')
-        monkeypatch.setenv('POSTGRES_NBGRADER_PASSWORD', 'test_pwd')
-        monkeypatch.setenv('POSTGRES_NBGRADER_DB', 'test_db')
-        monkeypatch.setenv('POSTGRES_NBGRADER_PORT', '5432')
+    def test_nbgrader_format_db_url_method_uses_env_vars_to_get_db_url(self, monkeypatch):
+        monkeypatch.setattr('illumidesk.apis.nbgrader_service.nbgrader_db_host', 'test_host')
+        monkeypatch.setattr('illumidesk.apis.nbgrader_service.nbgrader_db_password', 'test_pwd')
+        monkeypatch.setattr('illumidesk.apis.nbgrader_service.nbgrader_db_user', 'test_user')
 
-        sut = NbGraderServiceHelper('Course1')
-        assert sut.db_url == 'postgresql://test_user:test_pwd@test_host:5432/test_db'
+        assert nbgrader_format_db_url('Course 1') == 'postgresql://test_user:test_pwd@test_host:5432/my-org_course1'

--- a/src/tests/illumidesk/apis/test_nbgrader_service_helper.py
+++ b/src/tests/illumidesk/apis/test_nbgrader_service_helper.py
@@ -90,5 +90,6 @@ class TestNbGraderServiceHelper:
         monkeypatch.setattr('illumidesk.apis.nbgrader_service.nbgrader_db_host', 'test_host')
         monkeypatch.setattr('illumidesk.apis.nbgrader_service.nbgrader_db_password', 'test_pwd')
         monkeypatch.setattr('illumidesk.apis.nbgrader_service.nbgrader_db_user', 'test_user')
+        monkeypatch.setattr('illumidesk.apis.nbgrader_service.org_name', 'org-dummy')
 
-        assert nbgrader_format_db_url('Course 1') == 'postgresql://test_user:test_pwd@test_host:5432/my-org_course1'
+        assert nbgrader_format_db_url('Course 1') == 'postgresql://test_user:test_pwd@test_host:5432/org-dummy_course1'

--- a/src/tests/illumidesk/conftest.py
+++ b/src/tests/illumidesk/conftest.py
@@ -66,6 +66,7 @@ def mock_nbhelper():
                     'illumidesk.apis.nbgrader_service.NbGraderServiceHelper',
                     # __init__=lambda x, y: None,
                     update_course=Mock(return_value=None),
+                    create_database_if_not_exists=Mock(),
                     add_user_to_nbgrader_gradebook=Mock(return_value=None),
                     create_assignment_in_nbgrader=Mock(return_value=None),
                     get_course=Mock(


### PR DESCRIPTION
The course database will be created with the format: `<org_name>_<course-id>`. 

- The illumidesk **authenticator** class use this database for assignment creation
- Each shared grader service will contain the db_url inside `.jupyter/nbgrader_config.py` file