### PR TITLE
Refactor postgres container options

### DIFF
--- a/ansible/roles/jupyterhub/templates/docker-compose.yml.j2
+++ b/ansible/roles/jupyterhub/templates/docker-compose.yml.j2
@@ -27,8 +27,9 @@ services:
     image: {{docker_postgres_image}}
     container_name: jupyterhub-db
     restart: always
-    env_file:
-      - env.jhub
+    environment:
+      - POSTGRES_USER={{postgres_jupyterhub_user}}
+      - POSTGRES_PASSWORD={{postgres_jupyterhub_password}}
     volumes:
       - db:{{pg_data}}
   reverse-proxy:
@@ -60,8 +61,9 @@ services:
     image: {{docker_postgres_image}}
     container_name: {{postgres_nbgrader_host}}
     restart: always
-    env_file:
-      - env.common
+    environment:
+      - POSTGRES_USER={{postgres_nbgrader_user}}
+      - POSTGRES_PASSWORD={{postgres_nbgrader_password}}
     volumes:
       - db-nbgrader:{{pg_data}}
 {% endif %}
@@ -71,9 +73,8 @@ services:
     container_name: {{postgres_labs_host}}
     restart: always
     environment:
-      - POSTGRES_LABS_DB={{postgres_labs_db}}
-      - POSTGRES_LABS_USER={{postgres_labs_user}}
-      - POSTGRES_LABS_PASSWORD={{postgres_labs_password}}
+      - POSTGRES_USER={{postgres_labs_user}}
+      - POSTGRES_PASSWORD={{postgres_labs_password}}
     volumes:
       - db-labs:{{pg_data}}
 {% endif %}

--- a/ansible/roles/jupyterhub/templates/env.jhub.j2
+++ b/ansible/roles/jupyterhub/templates/env.jhub.j2
@@ -21,7 +21,7 @@ POSTGRES_JUPYTERHUB_DB={{postgres_jupyterhub_dbname}}
 POSTGRES_JUPYTERHUB_USER={{postgres_jupyterhub_user}}
 POSTGRES_JUPYTERHUB_PASSWORD={{postgres_jupyterhub_password}}
 POSTGRES_JUPYTERHUB_HOST={{postgres_jupyterhub_host}}
-POSTGRES_JUPYTERHUB_PORT={{postgres_jupyterhub_host}}
+POSTGRES_JUPYTERHUB_PORT={{postgres_jupyterhub_port}}
 
 # Mount directory root and permissions set with spawner
 NB_NON_GRADER_UID=1000

--- a/ansible/roles/jupyterhub/templates/env.jhub.j2
+++ b/ansible/roles/jupyterhub/templates/env.jhub.j2
@@ -21,7 +21,7 @@ POSTGRES_JUPYTERHUB_DB={{postgres_jupyterhub_dbname}}
 POSTGRES_JUPYTERHUB_USER={{postgres_jupyterhub_user}}
 POSTGRES_JUPYTERHUB_PASSWORD={{postgres_jupyterhub_password}}
 POSTGRES_JUPYTERHUB_HOST={{postgres_jupyterhub_host}}
-POSTGRES_JUPYTERHUB_PORT=={{postgres_jupyterhub_host}}
+POSTGRES_JUPYTERHUB_PORT={{postgres_jupyterhub_host}}
 
 # Mount directory root and permissions set with spawner
 NB_NON_GRADER_UID=1000

--- a/ansible/roles/jupyterhub/templates/jupyterhub_config_base.py.j2
+++ b/ansible/roles/jupyterhub/templates/jupyterhub_config_base.py.j2
@@ -88,11 +88,12 @@ c.JupyterHub.services = [
 ]
 
 # JupyterHub postgres settings
-c.JupyterHub.db_url = 'postgresql://{user}:{password}@{host}/{db}'.format(
-    user=os.environ.get('POSTGRES_USER'),
-    password=os.environ.get('POSTGRES_PASSWORD'),
-    host=os.environ.get('POSTGRES_HOST'),
-    db=os.environ.get('POSTGRES_DB'),
+c.JupyterHub.db_url = 'postgresql://{user}:{password}@{host}:{port}/{db}'.format(
+    user=os.environ.get('POSTGRES_JUPYTERHUB_USER'),
+    password=os.environ.get('POSTGRES_JUPYTERHUB_PASSWORD'),
+    host=os.environ.get('POSTGRES_JUPYTERHUB_HOST'),
+    port=os.environ.get('POSTGRES_JUPYTERHUB_PORT'),
+    db=os.environ.get('POSTGRES_JUPYTERHUB_DB'),
 )
 
 # Do not redirect user to his/her server (if running)

--- a/ansible/roles/setup_course/templates/env.setup_course.j2
+++ b/ansible/roles/setup_course/templates/env.setup_course.j2
@@ -19,10 +19,3 @@ JUPYTERHUB_SERVICE_NAME=jupyterhub
 
 # Grader user and group idsS
 NB_GRADER_UID=10001
-
-# Postgres settings for NBgrader
-POSTGRES_NBGRADER_DB={{postgres_nbgrader_dbname}}
-POSTGRES_NBGRADER_HOST={{postgres_nbgrader_host}}
-POSTGRES_NBGRADER_USER={{postgres_nbgrader_user}}
-POSTGRES_NBGRADER_PASSWORD={{postgres_nbgrader_password}}
-POSTGRES_NBGRADER_PORT={{postgres_nbgrader_port}}

--- a/src/tests/illumidesk/apps/test_jupyterhub_base_config.py
+++ b/src/tests/illumidesk/apps/test_jupyterhub_base_config.py
@@ -1,0 +1,46 @@
+
+import os
+import pytest
+
+from distutils.util import strtobool
+
+from traitlets.config import Config
+
+
+def test_jupyterhub_base_config(setup_jupyterhub_db, setup_jupyterhub_config_base):
+    """
+    Ensure all environment variables for the base config are set.
+    """
+    c = Config()
+    c.JupyterHub.base_url = os.environ.get('JUPYTERHUB_BASE_URL')
+    # JupyterHub postgres settings
+    c.JupyterHub.db_url = 'postgresql://{user}:{password}@{host}:{port}/{db}'.format(
+        user=os.environ.get('POSTGRES_JUPYTERHUB_USER'),
+        password=os.environ.get('POSTGRES_JUPYTERHUB_PASSWORD'),
+        host=os.environ.get('POSTGRES_JUPYTERHUB_HOST'),
+        port=os.environ.get('POSTGRES_JUPYTERHUB_PORT'),
+        db=os.environ.get('POSTGRES_JUPYTERHUB_DB'),
+    )
+    c.JupyterHub.shutdown_on_logout = bool(strtobool(os.environ.get('JUPYTERHUB_SHUTDOWN_ON_LOGOUT')))
+    c.Authenticator.admin_users = {os.environ.get('JUPYTERHUB_ADMIN_USER')}
+    c.Spawner.image = os.environ.get('DOCKER_END_USER_IMAGE')
+    c.Spawner.cpu_limit = float(os.environ.get('SPAWNER_CPU_LIMIT'))
+    c.Spawner.mem_limit = os.environ.get('SPAWNER_MEM_LIMIT')
+    c.DockerSpawner.network_name = os.environ.get('DOCKER_NETWORK_NAME')
+    docker_spawn_command = os.environ.get('DOCKER_SPAWN_CMD')
+    exchange_dir = os.environ.get('EXCHANGE_DIR')
+    notebook_dir = os.environ.get('DOCKER_NOTEBOOK_DIR')
+
+    assert c.Authenticator.admin_users == {'admin0'}
+
+    assert c.DockerSpawner.network_name == 'test-network'
+
+    assert c.JupyterHub.db_url == 'postgresql://foobar:abc123@jupyterhub-db:5432/jupyterhub'
+    assert c.JupyterHub.shutdown_on_logout == True
+
+    assert c.Spawner.cpu_limit == 0.5
+    assert c.Spawner.mem_limit == '2G'
+
+    assert docker_spawn_command == 'single_user_test.sh'
+    assert exchange_dir == '/path/to/exchange'
+    assert notebook_dir == '/home/saturn'

--- a/src/tests/illumidesk/conftest.py
+++ b/src/tests/illumidesk/conftest.py
@@ -287,13 +287,32 @@ def grades_controlfile_reset_file_loaded():
 
 
 @pytest.fixture(scope='function')
-def setup_jupyterhub_environment(monkeypatch):
+def setup_jupyterhub_db(monkeypatch):
     """
     Set the enviroment variables used to identify the end user image.
     """
-    monkeypatch.setenv('DOCKER_NETWORK_NAME', 'jupyter-network')
-    JUPYTERHUB_CRYPT_KEY
-    JUPYTERHUB_SHUTDOWN_ON_LOGOUT
+    monkeypatch.setenv('POSTGRES_JUPYTERHUB_DB', 'jupyterhub')
+    monkeypatch.setenv('POSTGRES_JUPYTERHUB_HOST', 'jupyterhub-db')
+    monkeypatch.setenv('POSTGRES_JUPYTERHUB_PORT', '5432')
+    monkeypatch.setenv('POSTGRES_JUPYTERHUB_USER', 'foobar')
+    monkeypatch.setenv('POSTGRES_JUPYTERHUB_PASSWORD', 'abc123')
+
+
+@pytest.fixture(scope='function')
+def setup_jupyterhub_config_base(monkeypatch):
+    """
+    Set the enviroment variables used to identify the end user image.
+    """
+    monkeypatch.setenv('JUPYTERHUB_BASE_URL', '/')
+    monkeypatch.setenv('JUPYTERHUB_SHUTDOWN_ON_LOGOUT', 'True')
+    monkeypatch.setenv('JUPYTERHUB_ADMIN_USER', 'admin0')
+    monkeypatch.setenv('SPAWNER_CPU_LIMIT', '0.5')
+    monkeypatch.setenv('SPAWNER_MEM_LIMIT', '2G')
+    monkeypatch.setenv('DOCKER_SPAWN_CMD', 'single_user_test.sh')
+    monkeypatch.setenv('DOCKER_NETWORK_NAME', 'test-network')
+    monkeypatch.setenv('EXCHANGE_DIR', '/path/to/exchange')
+    monkeypatch.setenv('DOCKER_NOTEBOOK_DIR', '/home/saturn')
+    monkeypatch.setenv('NB_NON_GRADER_UID', '1000')
 
 
 @pytest.fixture(scope='function')

--- a/src/tests/illumidesk/lti13/test_lti13_config_handler.py
+++ b/src/tests/illumidesk/lti13/test_lti13_config_handler.py
@@ -41,7 +41,9 @@ async def test_get_calls_write_method_with_a_json(mock_write, lti13_config_envir
 
 @pytest.mark.asyncio
 @patch('tornado.web.RequestHandler.write')
-async def test_get_method_writes_a_json_with_required_keys(mock_write, lti13_config_environ, make_mock_request_handler):
+async def test_get_method_writes_a_json_with_required_keys(
+    mock_write, lti13_config_environ, make_mock_request_handler
+):
     """
     Does the get method write a json (jwks) with essential fields?
     """


### PR DESCRIPTION
- Set default usernames / passwords for Postgres containers in docker-compose managed services
- Refactor env vars to avoid duplication
- Cleaner separation of nbgrader, labs, and JupyterHub Postgres services
- Basic tests to check env vars when loading stack

Closes #363 