### PR TITLE
Update UID in pre spawn hook to set user folder permissions

### DIFF
--- a/src/illumidesk/spawners/hooks.py
+++ b/src/illumidesk/spawners/hooks.py
@@ -55,7 +55,7 @@ def custom_pre_spawn_hook(spawner: Spawner) -> None:
         os.mkdir(user_path)
         shutil.chown(
             user_path,
-            user=int(os.environ.get('NB_GRADER_UID')),
+            user=int(os.environ.get('NB_NON_GRADER_UID')),
             group=int(os.environ.get('NB_GID')),
         )
         os.chmod(user_path, 0o755)

--- a/src/tests/illumidesk/apps/test_jupyterhub_base_config.py
+++ b/src/tests/illumidesk/apps/test_jupyterhub_base_config.py
@@ -1,6 +1,4 @@
-
 import os
-import pytest
 
 from distutils.util import strtobool
 
@@ -36,7 +34,7 @@ def test_jupyterhub_base_config(setup_jupyterhub_db, setup_jupyterhub_config_bas
     assert c.DockerSpawner.network_name == 'test-network'
 
     assert c.JupyterHub.db_url == 'postgresql://foobar:abc123@jupyterhub-db:5432/jupyterhub'
-    assert c.JupyterHub.shutdown_on_logout == True
+    assert c.JupyterHub.shutdown_on_logout == True  # noqa: E712
 
     assert c.Spawner.cpu_limit == 0.5
     assert c.Spawner.mem_limit == '2G'

--- a/src/tests/illumidesk/conftest.py
+++ b/src/tests/illumidesk/conftest.py
@@ -349,6 +349,15 @@ def setup_course_hook_environ(monkeypatch, jupyterhub_api_environ):
 
 
 @pytest.fixture(scope='function')
+def pre_spawn_hook_environ(monkeypatch, jupyterhub_api_environ):
+    """
+    Set the environment variables used in the setup_course_hook function
+    """
+    monkeypatch.setenv('NB_GID', '100')
+    monkeypatch.setenv('NB_NON_GRADER_UID', '1000')
+
+
+@pytest.fixture(scope='function')
 def setup_utils_environ(monkeypatch, tmp_path):
     """
     Set the enviroment variables used in SetupUtils class

--- a/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
+++ b/src/tests/illumidesk/spawners/test_illumidesk_dockerspawner.py
@@ -5,7 +5,7 @@ from dockerspawner.dockerspawner import DockerSpawner
 
 def test_dockerspawner_uses_raw_username_in_format_volume_name():
     """
-    Does the dockerspawner uses correctly the username?
+    Does the correctly use the username?
     """
     d = DockerSpawner()
     # notice we're not using variable for username,


### PR DESCRIPTION
Update the environment variable so that it uses the `NB_NON_GRADER_UID` instead of the `NB_GRADER_UID`.