### PR TITLE
Remove dependabot yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "11:00"
-  open-pull-requests-limit: 10


### PR DESCRIPTION
Removes dependabot.yaml to rely solely on dependabot configuration options available within the repo's settings.