### PR TITLE
Remove pytest-kind dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 .ipynb_checkpoints
 *.pid
 .pytest_cache
+.pytest-kind/
 *.retry
 .vim/
 .vscode

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -16,7 +16,6 @@ pytest-asyncio==0.14.0
 pytest-cov==2.10.1
 pytest-flask==1.2.0
 pytest-html==3.0.0
-pytest-kind==21.1.3
 pytest-metadata==1.10.0
 pytest-mock==3.3.1
 requests==2.25.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,176 +4,76 @@
 #
 #    pip-compile dev-requirements.in
 #
+appdirs==1.4.4            # via black, virtualenv
+attrs==20.3.0             # via pytest
+black==20.8b1             # via -r dev-requirements.in
+cachetools==4.2.0         # via google-auth
+certifi==2020.11.8        # via kubernetes, requests
+cfgv==3.2.0               # via pre-commit
+chardet==3.0.4            # via requests
+click==7.1.2              # via black, flask, pip-tools
+codecov==2.1.9            # via -r dev-requirements.in
+coverage==5.5             # via -r dev-requirements.in, codecov, pytest-cov
+distlib==0.3.1            # via virtualenv
+filelock==3.0.12          # via virtualenv
+flake8==3.9.0             # via -r dev-requirements.in
+flask-sqlalchemy==2.5.1   # via -r dev-requirements.in
+flask==1.1.2              # via -r dev-requirements.in, flask-sqlalchemy, pytest-flask
+google-auth==1.24.0       # via kubernetes
+gunicorn==20.1.0          # via -r dev-requirements.in
+httplib2==0.19.1          # via oauth2client
+identify==1.5.5           # via pre-commit
+idna==2.10                # via requests
+iniconfig==1.0.1          # via pytest
+isort==5.8.0              # via -r dev-requirements.in
+itsdangerous==1.1.0       # via flask
+jinja2==2.11.2            # via flask
+kubernetes==12.0.1        # via -r dev-requirements.in
+markupsafe==1.1.1         # via jinja2
+mccabe==0.6.1             # via flake8
+mock==4.0.2               # via -r dev-requirements.in
+mypy-extensions==0.4.3    # via black
+nodeenv==1.5.0            # via pre-commit
+oauth2client==4.1.3       # via pykube
+oauthlib==3.1.0           # via requests-oauthlib
+packaging==20.4           # via pytest
+pathspec==0.8.0           # via black
+pep517==0.10.0            # via pip-tools
+pip-tools==6.0.1          # via -r dev-requirements.in
+pluggy==0.13.1            # via pytest
+pre-commit==2.10.0        # via -r dev-requirements.in
+py==1.10.0                # via pytest
+pyasn1-modules==0.2.8     # via google-auth, oauth2client
+pyasn1==0.4.8             # via oauth2client, pyasn1-modules, rsa
+pycodestyle==2.7.0        # via flake8
+pyflakes==2.3.1           # via flake8
+pykube==0.15.0            # via -r dev-requirements.in
+pyparsing==2.4.7          # via httplib2, packaging
+pytest-asyncio==0.14.0    # via -r dev-requirements.in
+pytest-cov==2.10.1        # via -r dev-requirements.in
+pytest-flask==1.2.0       # via -r dev-requirements.in
+pytest-html==3.0.0        # via -r dev-requirements.in
+pytest-metadata==1.10.0   # via -r dev-requirements.in, pytest-html
+pytest-mock==3.3.1        # via -r dev-requirements.in
+pytest==6.2.2             # via -r dev-requirements.in, pytest-asyncio, pytest-cov, pytest-flask, pytest-html, pytest-metadata, pytest-mock
+python-dateutil==2.8.1    # via kubernetes
+pytz==2021.1              # via tzlocal
+pyyaml==5.4               # via kubernetes, pre-commit, pykube
+regex==2020.9.27          # via black
+requests-oauthlib==1.3.0  # via kubernetes, pykube
+requests==2.25.1          # via -r dev-requirements.in, codecov, kubernetes, pykube, requests-oauthlib
+rsa==4.6                  # via google-auth, oauth2client
+six==1.15.0               # via google-auth, kubernetes, oauth2client, packaging, pykube, python-dateutil, virtualenv, websocket-client
+sqlalchemy==1.3.20        # via flask-sqlalchemy
+toml==0.10.1              # via black, pep517, pre-commit, pytest
+typed-ast==1.4.1          # via black
+typing-extensions==3.7.4.3  # via black
+tzlocal==2.1              # via pykube
+urllib3==1.25.11          # via kubernetes, requests
+virtualenv==20.0.33       # via pre-commit
+websocket-client==0.57.0  # via kubernetes
+werkzeug==1.0.1           # via flask, pytest-flask
 
-appdirs==1.4.4
-    # via
-    #   black
-    #   virtualenv
-attrs==20.3.0
-    # via pytest
-black==20.8b1
-    # via -r dev-requirements.in
-cachetools==4.2.0
-    # via google-auth
-certifi==2020.11.8
-    # via
-    #   kubernetes
-    #   requests
-cfgv==3.2.0
-    # via pre-commit
-chardet==3.0.4
-    # via requests
-click==7.1.2
-    # via
-    #   black
-    #   flask
-    #   pip-tools
-codecov==2.1.9
-    # via -r dev-requirements.in
-coverage==5.5
-    # via
-    #   -r dev-requirements.in
-    #   codecov
-    #   pytest-cov
-distlib==0.3.1
-    # via virtualenv
-filelock==3.0.12
-    # via virtualenv
-flake8==3.9.0
-    # via -r dev-requirements.in
-flask-sqlalchemy==2.5.1
-    # via -r dev-requirements.in
-flask==1.1.2
-    # via
-    #   -r dev-requirements.in
-    #   flask-sqlalchemy
-    #   pytest-flask
-google-auth==1.24.0
-    # via kubernetes
-gunicorn==20.1.0
-    # via -r dev-requirements.in
-identify==1.5.5
-    # via pre-commit
-idna==2.10
-    # via requests
-iniconfig==1.0.1
-    # via pytest
-isort==5.8.0
-    # via -r dev-requirements.in
-itsdangerous==1.1.0
-    # via flask
-jinja2==2.11.2
-    # via flask
-kubernetes==12.0.1
-    # via -r dev-requirements.in
-markupsafe==1.1.1
-    # via jinja2
-mccabe==0.6.1
-    # via flake8
-mock==4.0.2
-    # via -r dev-requirements.in
-mypy-extensions==0.4.3
-    # via black
-nodeenv==1.5.0
-    # via pre-commit
-oauthlib==3.1.0
-    # via requests-oauthlib
-packaging==20.4
-    # via pytest
-pathspec==0.8.0
-    # via black
-pep517==0.10.0
-    # via pip-tools
-pip-tools==6.0.1
-    # via -r dev-requirements.in
-pluggy==0.13.1
-    # via pytest
-pre-commit==2.10.0
-    # via -r dev-requirements.in
-py==1.10.0
-    # via pytest
-pyasn1-modules==0.2.8
-    # via google-auth
-pyasn1==0.4.8
-    # via
-    #   pyasn1-modules
-    #   rsa
-pycodestyle==2.7.0
-    # via flake8
-pyflakes==2.3.1
-    # via flake8
-pyparsing==2.4.7
-    # via packaging
-pytest-asyncio==0.14.0
-    # via -r dev-requirements.in
-pytest-cov==2.10.1
-    # via -r dev-requirements.in
-pytest-flask==1.2.0
-    # via -r dev-requirements.in
-pytest-html==3.0.0
-    # via -r dev-requirements.in
-pytest-metadata==1.10.0
-    # via
-    #   -r dev-requirements.in
-    #   pytest-html
-pytest-mock==3.3.1
-    # via -r dev-requirements.in
-pytest==6.2.2
-    # via
-    #   -r dev-requirements.in
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-flask
-    #   pytest-html
-    #   pytest-metadata
-    #   pytest-mock
-python-dateutil==2.8.1
-    # via kubernetes
-pyyaml==5.4
-    # via
-    #   kubernetes
-    #   pre-commit
-regex==2020.9.27
-    # via black
-requests-oauthlib==1.3.0
-    # via kubernetes
-requests==2.25.1
-    # via
-    #   -r dev-requirements.in
-    #   codecov
-    #   kubernetes
-    #   requests-oauthlib
-rsa==4.6
-    # via google-auth
-six==1.15.0
-    # via
-    #   google-auth
-    #   kubernetes
-    #   packaging
-    #   python-dateutil
-    #   virtualenv
-    #   websocket-client
-sqlalchemy==1.3.20
-    # via flask-sqlalchemy
-toml==0.10.1
-    # via
-    #   black
-    #   pep517
-    #   pre-commit
-    #   pytest
-typed-ast==1.4.1
-    # via black
-typing-extensions==3.7.4.3
-    # via black
-urllib3==1.25.11
-    # via
-    #   kubernetes
-    #   requests
-virtualenv==20.0.33
-    # via pre-commit
-websocket-client==0.57.0
-    # via kubernetes
-werkzeug==1.0.1
-    # via
-    #   flask
-    #   pytest-flask
+# The following packages are considered to be unsafe in a requirements file:
+# pip
+# setuptools


### PR DESCRIPTION
Removes `pytest-kind` dependency. This dependency will be re-enabled once we set up e2e tests with a test Kubernetes cluster using Kind.