### PR TITLE
Change dummy authenticator to use standard login path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,11 @@ clean:
 test: dev
 	${VENV_BIN}/pytest -v src/illumidesk
 	${VENV_BIN}/pytest -v src/graderservice
+
+build-hubs-k8:
+	@docker build --build-arg BASE_IMAGE=jupyterhub/k8s-hub:0.11.1-n495.h232e257c -t illumidesk/k8s-hub:1.4.1 src/illumidesk/. --no-cache
+	@docker build --build-arg BASE_IMAGE=illumidesk/k8s-hub:1.4.1 -t illumidesk/k8s-hub:dummy-auth-1.4.1 src/illumideskdummyauthenticator/. --no-cache
+
+build-hubs:
+	@docker build --build-arg BASE_IMAGE=jupyterhub/jupyterhub:1.4.1 -t illumidesk/jupyterhub:1.4.1 src/illumidesk/. --no-cache
+	@docker build --build-arg BASE_IMAGE=illumidesk/jupyterhub:1.4.1 -t illumidesk/jupyterhub:dummy-auth-1.4.1 src/illumideskdummyauthenticator/. --no-cache

--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ This setup only supports Kubernetes-based installations at this time. Refer to t
 
 Refer to the [contributing](./CONTRIBUTING.md) guide located in the root of this repo.
 
+### Building the JupyterHubs
+
+1. Build the JupyterHub for local testing with `docker-compose` or `docker`:
+
+```bash
+make build-hubs
+```
+
+1. Build the JupyterHub for local testing with `Kubernetes`:
+
+```bash
+make build-hubs-k8
+```
 ### General Guidelines
 
 This project enforces the [Contributor Covenant](./CODE_OF_CONDUCT.md). Be kind and build a nice open source community with us.

--- a/src/illumidesk/illumidesk/authenticators/authenticator.py
+++ b/src/illumidesk/illumidesk/authenticators/authenticator.py
@@ -61,7 +61,7 @@ async def setup_course_hook_lti11(
     course_id = lti_utils.normalize_string(
         authentication["auth_state"]["context_label"]
     )
-    nb_service = NbGraderServiceHelper(course_id)
+    nb_service = NbGraderServiceHelper(course_id, True)
 
     # register the user (it doesn't matter if it is a student or instructor) with her/his lms_user_id in nbgrader
     nb_service.add_user_to_nbgrader_gradebook(username, lms_user_id)
@@ -122,7 +122,7 @@ async def setup_course_hook(
 
     # normalize the name and course_id strings in authentication dictionary
     course_id = lti_utils.normalize_string(authentication["auth_state"]["course_id"])
-    nb_service = NbGraderServiceHelper(course_id)
+    nb_service = NbGraderServiceHelper(course_id, True)
     username = lti_utils.normalize_string(authentication["name"])
     lms_user_id = authentication["auth_state"]["lms_user_id"]
     user_role = authentication["auth_state"]["user_role"]
@@ -151,7 +151,7 @@ async def setup_course_hook(
 
     # launch the new grader-notebook as a service
     try:
-        new_setup = await register_new_service(org_name=ORG_NAME, course_id=course_id)
+        _ = await register_new_service(org_name=ORG_NAME, course_id=course_id)
     except Exception as e:
         logger.error("Unable to launch the shared grader notebook with exception %s", e)
 

--- a/src/illumidesk/tests/illumidesk/authenticators/test_setup_course_hook.py
+++ b/src/illumidesk/tests/illumidesk/authenticators/test_setup_course_hook.py
@@ -54,44 +54,38 @@ async def test_setup_course_hook_calls_add_student_to_jupyterhub_group_when_role
             assert mock_add_student_to_jupyterhub_group.called
 
 
-@patch("shutil.chown")
-@patch("pathlib.Path.mkdir")
-@patch("illumidesk.apis.nbgrader_service.Gradebook")
 @pytest.mark.asyncio()
-async def test_setup_course_hook_calls_add_user_to_nbgrader_gradebook_when_role_is_learner(
-    mock_mkdir,
-    mock_chown,
-    mock_gradebook,
+async def test_setup_course_hook_calls_add_student_to_jupyterhub_group_when_role_is_learner(
     monkeypatch,
     setup_course_environ,
     setup_course_hook_environ,
-    setup_nbgrader_db,
     make_auth_state_dict,
     make_mock_request_handler,
     make_http_response,
+    mock_nbhelper,
 ):
     """
-    Is the jupyterhub_api add user to nbgrader gradebook function called when the user role is
+    Is the jupyterhub_api add learner to jupyterhub group function called when the user role is
     the learner role?
     """
     local_authenticator = Authenticator(post_auth_hook=setup_course_hook)
     local_handler = make_mock_request_handler(
         RequestHandler, authenticator=local_authenticator
     )
-    local_authentication = make_auth_state_dict()
+    local_authentication = make_auth_state_dict(user_role="Learner")
 
     with patch.object(
-        NbGraderServiceHelper, "add_user_to_nbgrader_gradebook", return_value=None
-    ) as mock_add_user_to_nbgrader_gradebook:
+        JupyterHubAPI, "add_student_to_jupyterhub_group", return_value=None
+    ) as mock_add_student_to_jupyterhub_group:
         with patch.object(
             AsyncHTTPClient,
             "fetch",
             return_value=make_http_response(handler=local_handler.request),
         ):
-            result = await setup_course_hook(
+            await setup_course_hook(
                 local_authenticator, local_handler, local_authentication
             )
-            assert mock_add_user_to_nbgrader_gradebook.called
+            assert mock_add_student_to_jupyterhub_group.called
 
 
 @pytest.mark.asyncio()

--- a/src/illumideskdummyauthenticator/README.md
+++ b/src/illumideskdummyauthenticator/README.md
@@ -72,6 +72,6 @@ docker build \
 2. Create a value for the `JUPYTERHUB_CRYPT_KEY` environment variable: `openssl rand -hex 32`
 3. Configure the `illumidesk/illumidesk` [helm chart](https://github.com/illumidesk/helm-chart) to set the `authenticator_class` and the `post_auth_hook` mentioned above.
 4. Deploy the `illumidesk/illumidesk` application to a `kubernetes` cluster. [Refer to IllumiDesk's helm-chart repo](https://github.com/illumidesk/helm-chart) for further instructions.
-5. Navigate to `https://<external-facing-address>/hub/dummy/login`.
+5. Navigate to `https://<external-facing-address>/hub/login`.
 
 > **NOTE**: when using docker your IPv4 address may not work with localhost.

--- a/src/illumideskdummyauthenticator/illumideskdummyauthenticator/authenticator.py
+++ b/src/illumideskdummyauthenticator/illumideskdummyauthenticator/authenticator.py
@@ -27,7 +27,7 @@ class IllumiDeskDummyAuthenticator(Authenticator):
     """
 
     def get_handlers(self, app: JupyterHub) -> BaseHandler:
-        return [("/dummy/login", IllumiDeskDummyLoginHandler)]
+        return [("/login", IllumiDeskDummyLoginHandler)]
 
     async def authenticate(  # noqa: C901
         self, handler: BaseHandler, data: Dict[str, Any] = None

--- a/src/illumideskdummyauthenticator/tests/test_handlers.py
+++ b/src/illumideskdummyauthenticator/tests/test_handlers.py
@@ -7,4 +7,4 @@ async def test_handlers(hubapp):
     """Test if all handlers are available on the Authenticator"""
     auth = IllumiDeskDummyAuthenticator()
     handlers = auth.get_handlers(hubapp)
-    assert handlers[0][0] == "/dummy/login"
+    assert handlers[0][0] == "/login"


### PR DESCRIPTION
- Replaces the login URL to use `/login` instead of  `/dummy/login`.
- Updates `Makefile` to include commands to build Kubernetes/Docker versions of the JupyterHub