### PR TITLE
Remove int cast for gid/uid

### DIFF
--- a/src/graderservice/graderservice/graderservice.py
+++ b/src/graderservice/graderservice/graderservice.py
@@ -39,8 +39,8 @@ GRADER_EXCHANGE_SHARED_PVC = os.environ.get(
 )
 
 # user UI and GID to use within the grader container
-NB_UID = int(os.environ.get("NB_UID", 10001))
-NB_GID = int(os.environ.get("NB_GID", 100))
+NB_UID = os.environ.get("NB_UID", 10001)
+NB_GID = os.environ.get("NB_GID", 100)
 
 # NBGrader DATABASE settings to save in nbgrader_config.py file
 nbgrader_db_host = os.environ.get("POSTGRES_NBGRADER_HOST")


### PR DESCRIPTION
Removes the int cast for the NB_GID and NB_UID environment variables in the grader service.

This was added when reviewing bug sources for the failing grader-setup-service and finally settled on merging #602, but inadvertently left this cast in place which is not necessary.