### PR TITLE
Bump jupyterhub to 1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # IllumiDesk
 
 This monorepo is used to maintain IllumiDesk's authenticators, spawners, and microservices. This setup assumes that all services are running with Kubernetes.
-Please refer to our [help guides](https://help.illumidesk.com) for more information.
+Please refer to our [help guides](https://support.illumidesk.com) for more information.
 
 ## Overview
 

--- a/src/illumidesk/Dockerfile
+++ b/src/illumidesk/Dockerfile
@@ -1,6 +1,6 @@
 # for kubernetes, use the --build-arg when building image or uncomment
-# ARG BASE_IMAGE=jupyterhub/k8s-hub:1.0.1-n014.h8c8ee4a0
-ARG BASE_IMAGE=jupyterhub/jupyterhub:1.4.1
+# ARG BASE_IMAGE=jupyterhub/k8s-hub:1.1.1
+ARG BASE_IMAGE=jupyterhub/jupyterhub:1.4.2
 FROM "${BASE_IMAGE}"
 
 USER root

--- a/src/illumideskdummyauthenticator/Dockerfile
+++ b/src/illumideskdummyauthenticator/Dockerfile
@@ -1,6 +1,6 @@
 # for kubernetes, use the --build-arg when building image or uncomment
-# ARG BASE_IMAGE=illumidesk/k8s-hub:1.0.1-n014.h8c8ee4a0
-ARG BASE_IMAGE=illumidesk/jupyterhub:1.4.1
+# ARG BASE_IMAGE=illumidesk/k8s-hub:1.1.1
+ARG BASE_IMAGE=illumidesk/jupyterhub:1.4.2
 FROM "${BASE_IMAGE}"
 
 USER "${NB_UID}"

--- a/src/illumideskdummyauthenticator/README.md
+++ b/src/illumideskdummyauthenticator/README.md
@@ -64,7 +64,7 @@ docker run -d \
 
 ```bash
 docker build \
-  --build-arg BASE_IMAGE=illumidesk/k8s-hub:1.0.1-n014.h8c8ee4a0 \
+  --build-arg BASE_IMAGE=illumidesk/k8s-hub:1.1.1 \
   -t illumidesk/jupyterhub:test . \
   --no-cache
 ```


### PR DESCRIPTION
- Updates jupyterhub/jupyterhub base images in Dockerfile to use v1.4.2 by default (version from JupyterHub release)
- Updates jupyterhub/k8s-hub base images in Dockerfile to use v1.1.1 by default (version from helm chart)
- Updates README example to build `illumidesk/k8s-hub` with latest version

Closes #600 