### PR TITLE
Update graderservice requests and limits defaults

### DIFF
--- a/src/graderservice/README.md
+++ b/src/graderservice/README.md
@@ -35,8 +35,8 @@ flask run
 | GRADER_SHARED_PVC | The shared grader notebook PVC for the exchange directory | `string` | `exchange-shared-volume` |
 | GRADER_REQUESTS_MEM | The guaranteed amount of memory (RAM). | `string` | `""` |
 | GRADER_REQUESTS_CPU | The guaranteed CPU. | `string` | `""` |
-| GRADER_LIMITS_MEM | The upper bound memory (RAM) limit. | `string` | `"500Mi"` |
-| GRADER_LIMITS_CPU | The upper bound CPU limit. | `string` | `"1000m"` |
+| GRADER_LIMITS_MEM | The upper bound memory (RAM) limit. | `string` | `"4G"` |
+| GRADER_LIMITS_CPU | The upper bound CPU limit. | `string` | `"2000m"` |
 | ILLUMIDESK_MNT_ROOT | Root directory for `{org_name}/grader-{course_id}` | `string` | `/illumidesk-courses` |
 | ILLUMIDESK_NB_EXCHANGE_MNT_ROOT | Root directory for `{org_name}/exchange` | `string` | `/illumidesk-nb-exchange` |
 | IS_DEBUG | Sets the debug option to True or False for the Kubernetes client and the shared grader notebook | `bool` | `True` |

--- a/src/graderservice/graderservice/graderservice.py
+++ b/src/graderservice/graderservice/graderservice.py
@@ -43,16 +43,16 @@ NB_UID = os.environ.get("NB_UID", 10001)
 NB_GID = os.environ.get("NB_GID", 100)
 
 # Shared grader notebook CPU and Memory settings
-GRADER_REQUEST_MEM = os.environ.get("GRADER_REQUEST_MEM")
-GRADER_REQUEST_CPU = os.environ.get("GRADER_REQUEST_CPU")
-GRADER_LIMIT_MEM = os.environ.get("GRADER_LIMIT_MEM") or "1G"
-GRADER_LIMIT_CPU = os.environ.get("GRADER_LIMIT_CPU") or "500m"
+GRADER_REQUESTS_MEM = os.environ.get("GRADER_REQUESTS_MEM")
+GRADER_REQUESTS_CPU = os.environ.get("GRADER_REQUESTS_CPU")
+GRADER_LIMITS_MEM = os.environ.get("GRADER_LIMITS_MEM") or "4G"
+GRADER_LIMITS_CPU = os.environ.get("GRADER_LIMITS_CPU") or "2000m"
 
 # JupyterHub settings
 JUPYTERHUB_API_URL = os.environ.get("JUPYTERHUB_API_URL") or "http://hub:8081/hub/api"
 JUPYTERHUB_BASE_URL = os.environ.get("JUPYTERHUB_BASE_URL") or "/"
 
-# NBGrader DATABASE settings to save in nbgrader_config.py file
+# NBGrader database settings to save in nbgrader_config.py file
 nbgrader_db_host = os.environ.get("POSTGRES_NBGRADER_HOST")
 nbgrader_db_password = os.environ.get("POSTGRES_NBGRADER_PASSWORD")
 nbgrader_db_user = os.environ.get("POSTGRES_NBGRADER_USER")
@@ -235,12 +235,12 @@ class GraderServiceLauncher:
             working_dir=f"/home/{self.grader_name}",
             resources=client.V1ResourceRequirements(
                 requests={
-                    "cpu": os.environ.get("GRADER_REQUESTS_CPU"),
-                    "memory": os.environ.get("GRADER_REQUESTS_MEM"),
+                    "cpu": GRADER_REQUESTS_CPU,
+                    "memory": GRADER_REQUESTS_MEM,
                 },
                 limits={
-                    "cpu": os.environ.get("GRADER_LIMITS_CPU"),
-                    "memory": os.environ.get("GRADER_LIMITS_MEM"),
+                    "cpu": GRADER_LIMITS_CPU,
+                    "memory": GRADER_LIMITS_MEM,
                 },
             ),
             security_context=client.V1SecurityContext(allow_privilege_escalation=False),


### PR DESCRIPTION
- Updates the graderservice package to have 2CPU and 4GB as resource limits
- Sets the CPU/Memory limits from env vars
- Renames variables to use the requests and limits vs request and limit for consistency with K8s names

Closes #615 