### PR TITLE
Fix invalid authentication flow when using line items to identify the assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,9 @@ test: dev
 	${VENV_BIN}/pytest -v src/graderservice
 
 build-hubs-k8:
-	@docker build --build-arg BASE_IMAGE=jupyterhub/k8s-hub:0.11.1-n495.h232e257c -t illumidesk/k8s-hub:1.4.1 src/illumidesk/. --no-cache
-	@docker build --build-arg BASE_IMAGE=illumidesk/k8s-hub:1.4.1 -t illumidesk/k8s-hub:dummy-auth-1.4.1 src/illumideskdummyauthenticator/. --no-cache
+	@docker build --build-arg BASE_IMAGE=jupyterhub/k8s-hub:1.1.2 -t illumidesk/k8s-hub:base-1.1.2 src/illumidesk/. --no-cache
+	@docker build --build-arg BASE_IMAGE=illumidesk/k8s-hub:base-1.1.2 -t illumidesk/k8s-hub:1.1.2 src/illumideskdummyauthenticator/. --no-cache
 
 build-hubs:
-	@docker build --build-arg BASE_IMAGE=jupyterhub/jupyterhub:1.4.1 -t illumidesk/jupyterhub:1.4.1 src/illumidesk/. --no-cache
-	@docker build --build-arg BASE_IMAGE=illumidesk/jupyterhub:1.4.1 -t illumidesk/jupyterhub:dummy-auth-1.4.1 src/illumideskdummyauthenticator/. --no-cache
+	@docker build --build-arg BASE_IMAGE=jupyterhub/jupyterhub:1.4.2 -t illumidesk/jupyterhub:1.4.2 src/illumidesk/. --no-cache
+	@docker build --build-arg BASE_IMAGE=illumidesk/jupyterhub:1.4.2 -t illumidesk/jupyterhub:dummy-auth-1.4.2 src/illumideskdummyauthenticator/. --no-cache

--- a/src/illumidesk/Dockerfile
+++ b/src/illumidesk/Dockerfile
@@ -1,5 +1,5 @@
 # for kubernetes, use the --build-arg when building image or uncomment
-# ARG BASE_IMAGE=jupyterhub/k8s-hub:1.1.1
+# ARG BASE_IMAGE=jupyterhub/k8s-hub:1.1.2
 ARG BASE_IMAGE=jupyterhub/jupyterhub:1.4.2
 FROM "${BASE_IMAGE}"
 

--- a/src/illumidesk/illumidesk/authenticators/authenticator.py
+++ b/src/illumidesk/illumidesk/authenticators/authenticator.py
@@ -323,17 +323,7 @@ async def process_resource_link_lti_13(
         "https://purl.imsglobal.org/spec/lti/claim/resource_link"
     ]
     resource_link_title = resource_link["title"] or ""
-    course_lineitems = ""
-    if (
-        "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint" in jwt_body_decoded
-        and "lineitems"
-        in jwt_body_decoded["https://purl.imsglobal.org/spec/lti-ags/claim/endpoint"]
-    ):
-        course_lineitems = jwt_body_decoded[
-            "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint"
-        ]["lineitems"]
     nbgrader_service = NbGraderServiceHelper(course_id, True)
-    nbgrader_service.update_course(lms_lineitems_endpoint=course_lineitems)
     if resource_link_title:
         assignment_name = LTIUtils().normalize_string(resource_link_title)
         logger.debug(

--- a/src/illumidesk/tests/illumidesk/authenticators/test_lti13_authenticator.py
+++ b/src/illumidesk/tests/illumidesk/authenticators/test_lti13_authenticator.py
@@ -332,7 +332,7 @@ async def test_authenticator_returns_username_in_auth_state_with_privacy_enabled
     mock_nbhelper,
 ):
     """
-    Do we get a valid username when only including lis person sourcedid resource link request?
+    Do we get a valid username when privacy is enabled?
     """
     authenticator = LTI13Authenticator()
     request_handler = make_mock_request_handler(
@@ -357,36 +357,6 @@ async def test_authenticator_returns_username_in_auth_state_with_privacy_enabled
             result = await authenticator.authenticate(request_handler, None)
 
             assert result["name"] == "4"
-
-
-# @pytest.mark.asyncio
-# async def test_authenticator_returns_username_in_auth_state_with_privacy_enabled(
-#     make_lti13_resource_link_request_privacy_enabled,
-#     build_lti13_jwt_id_token,
-#     make_mock_request_handler,
-#     mock_nbhelper,
-# ):
-#     """
-#     Do we get a valid username when initiating the login flow with privacy enabled?
-#     """
-#     authenticator = LTI13Authenticator()
-#     request_handler = make_mock_request_handler(
-#         RequestHandler, authenticator=authenticator
-#     )
-
-#     with patch.object(
-#         RequestHandler,
-#         "get_argument",
-#         return_value=build_lti13_jwt_id_token(
-#             make_lti13_resource_link_request_privacy_enabled
-#         ),
-#     ):
-#         with patch.object(
-#             LTI13LaunchValidator, "validate_launch_request", return_value=True
-#         ):
-#             result = await authenticator.authenticate(request_handler, None)
-
-#             assert result["name"] == "4"
 
 
 @pytest.mark.asyncio

--- a/src/illumideskdummyauthenticator/Dockerfile
+++ b/src/illumideskdummyauthenticator/Dockerfile
@@ -1,5 +1,5 @@
 # for kubernetes, use the --build-arg when building image or uncomment
-# ARG BASE_IMAGE=illumidesk/k8s-hub:1.1.1
+# ARG BASE_IMAGE=illumidesk/k8s-hub:1.1.2
 ARG BASE_IMAGE=illumidesk/jupyterhub:1.4.2
 FROM "${BASE_IMAGE}"
 


### PR DESCRIPTION
- Removes the reference to the line item from the LTI 1.3 claim during the authentication flow
- Removes the call to the nbgrader grade book to update the assignment record with the custom line item field (no longer applicable)
- Bumps the Jupyterhub version to 1.4.2 using the helm chart image version 1.1.2

Closes #617 