### PR TITLE
Remove header and footer settings from config

### DIFF
--- a/src/graderservice/graderservice/templates.py
+++ b/src/graderservice/graderservice/templates.py
@@ -15,6 +15,4 @@ NBGRADER_COURSE_CONFIG_TEMPLATE = """
 c = get_config()
 
 c.CourseDirectory.course_id = '{course_id}'
-c.IncludeHeaderFooter.header = 'source/header.ipynb'
-c.IncludeHeaderFooter.footer = 'source/footer.ipynb'
 """


### PR DESCRIPTION
Removes the header and footer templates from the standard `nbgrader_config.py` for shared grader notebooks.